### PR TITLE
[FEAT/#40] 공용 훅 마이그레이션 및 구현

### DIFF
--- a/apps/web/src/shared/constants/breakpoints.ts
+++ b/apps/web/src/shared/constants/breakpoints.ts
@@ -1,0 +1,11 @@
+export const BREAKPOINTS = {
+  mobile: 0,
+  tablet: 768,
+  desktop: 1200,
+} as const;
+
+export const MEDIA_QUERIES = {
+  mobile: '(max-width: 767px)',
+  tablet: '(min-width: 768px) and (max-width: 1199px)',
+  desktop: '(min-width: 1200px)',
+} as const;

--- a/apps/web/src/shared/constants/index.ts
+++ b/apps/web/src/shared/constants/index.ts
@@ -1,2 +1,3 @@
 export * from './tanstack-query';
 export * from './auth';
+export * from './breakpoints';

--- a/apps/web/src/shared/hooks/index.ts
+++ b/apps/web/src/shared/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './useDebounce';
+export * from './useInfiniteScroll';

--- a/apps/web/src/shared/hooks/index.ts
+++ b/apps/web/src/shared/hooks/index.ts
@@ -1,2 +1,3 @@
+export * from './useBreakpoint';
 export * from './useDebounce';
 export * from './useInfiniteScroll';

--- a/apps/web/src/shared/hooks/useBreakpoint.ts
+++ b/apps/web/src/shared/hooks/useBreakpoint.ts
@@ -4,6 +4,15 @@ import { useState, useEffect } from 'react';
 
 import { MEDIA_QUERIES } from '../constants';
 
+/**
+ * 현재 뷰포트의 반응형 디자인 브레이크포인트 상태를 감지하는 커스텀 훅입니다.
+ * MEDIA_QUERIES에 정의된 기준에 따라 모바일, 태블릿, 데스크탑 여부를 반환합니다.
+ *
+ * @returns {{isMobile: boolean, isTablet: boolean, isDesktop: boolean}} 현재 브레이크포인트 상태를 나타내는 객체
+ * - isMobile: 뷰포트가 모바일 브레이크포인트에 해당하는 경우 true
+ * - isTablet: 뷰포트가 태블릿 브레이크포인트에 해당하는 경우 true
+ * - isDesktop: 뷰포트가 데스크탑 브레이크포인트에 해당하는 경우 true
+ */
 export const useBreakpoint = () => {
   const [breakpoint, setBreakpoint] = useState({
     isMobile: false,

--- a/apps/web/src/shared/hooks/useBreakpoint.ts
+++ b/apps/web/src/shared/hooks/useBreakpoint.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+import { MEDIA_QUERIES } from '../constants';
+
+export const useBreakpoint = () => {
+  const [breakpoint, setBreakpoint] = useState({
+    isMobile: false,
+    isTablet: false,
+    isDesktop: false,
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const mobileQuery = window.matchMedia(MEDIA_QUERIES.mobile);
+    const tabletQuery = window.matchMedia(MEDIA_QUERIES.tablet);
+    const desktopQuery = window.matchMedia(MEDIA_QUERIES.desktop);
+
+    const updateBreakpoint = () => {
+      setBreakpoint({
+        isMobile: mobileQuery.matches,
+        isTablet: tabletQuery.matches,
+        isDesktop: desktopQuery.matches,
+      });
+    };
+
+    updateBreakpoint();
+
+    mobileQuery.addEventListener('change', updateBreakpoint);
+    tabletQuery.addEventListener('change', updateBreakpoint);
+    desktopQuery.addEventListener('change', updateBreakpoint);
+
+    return () => {
+      mobileQuery.removeEventListener('change', updateBreakpoint);
+      tabletQuery.removeEventListener('change', updateBreakpoint);
+      desktopQuery.removeEventListener('change', updateBreakpoint);
+    };
+  }, []);
+
+  return breakpoint;
+};

--- a/apps/web/src/shared/hooks/useBreakpoint.ts
+++ b/apps/web/src/shared/hooks/useBreakpoint.ts
@@ -23,28 +23,31 @@ export const useBreakpoint = () => {
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
-    const mobileQuery = window.matchMedia(MEDIA_QUERIES.mobile);
-    const tabletQuery = window.matchMedia(MEDIA_QUERIES.tablet);
-    const desktopQuery = window.matchMedia(MEDIA_QUERIES.desktop);
+    const mediaQueryLists = {
+      mobile: window.matchMedia(MEDIA_QUERIES.mobile),
+      tablet: window.matchMedia(MEDIA_QUERIES.tablet),
+      desktop: window.matchMedia(MEDIA_QUERIES.desktop),
+    };
 
     const updateBreakpoint = () => {
       setBreakpoint({
-        isMobile: mobileQuery.matches,
-        isTablet: tabletQuery.matches,
-        isDesktop: desktopQuery.matches,
+        isMobile: mediaQueryLists.mobile.matches,
+        isTablet: mediaQueryLists.tablet.matches,
+        isDesktop: mediaQueryLists.desktop.matches,
       });
     };
 
     updateBreakpoint();
 
-    mobileQuery.addEventListener('change', updateBreakpoint);
-    tabletQuery.addEventListener('change', updateBreakpoint);
-    desktopQuery.addEventListener('change', updateBreakpoint);
+    const queries = Object.values(mediaQueryLists);
+    queries.forEach((query) =>
+      query.addEventListener('change', updateBreakpoint),
+    );
 
     return () => {
-      mobileQuery.removeEventListener('change', updateBreakpoint);
-      tabletQuery.removeEventListener('change', updateBreakpoint);
-      desktopQuery.removeEventListener('change', updateBreakpoint);
+      queries.forEach((query) =>
+        query.removeEventListener('change', updateBreakpoint),
+      );
     };
   }, []);
 

--- a/apps/web/src/shared/hooks/useBreakpoint.ts
+++ b/apps/web/src/shared/hooks/useBreakpoint.ts
@@ -8,16 +8,16 @@ import { MEDIA_QUERIES } from '../constants';
  * 현재 뷰포트의 반응형 디자인 브레이크포인트 상태를 감지하는 커스텀 훅입니다.
  * MEDIA_QUERIES에 정의된 기준에 따라 모바일, 태블릿, 데스크탑 여부를 반환합니다.
  *
- * @returns {{isMobile: boolean, isTablet: boolean, isDesktop: boolean}} 현재 브레이크포인트 상태를 나타내는 객체
- * - isMobile: 뷰포트가 모바일 브레이크포인트에 해당하는 경우 true
- * - isTablet: 뷰포트가 태블릿 브레이크포인트에 해당하는 경우 true
- * - isDesktop: 뷰포트가 데스크탑 브레이크포인트에 해당하는 경우 true
+ * @returns {{isMobileSize: boolean, isTabletSize: boolean, isDesktopSize: boolean}} 현재 브레이크포인트 상태를 나타내는 객체
+ * - isMobileSize: 뷰포트가 모바일 브레이크포인트에 해당하는 경우 true
+ * - isTabletSize: 뷰포트가 태블릿 브레이크포인트에 해당하는 경우 true
+ * - isDesktopSize: 뷰포트가 데스크탑 브레이크포인트에 해당하는 경우 true
  */
 export const useBreakpoint = () => {
   const [breakpoint, setBreakpoint] = useState({
-    isMobile: false,
-    isTablet: false,
-    isDesktop: false,
+    isMobileSize: false,
+    isTabletSize: false,
+    isDesktopSize: false,
   });
 
   useEffect(() => {
@@ -31,9 +31,9 @@ export const useBreakpoint = () => {
 
     const updateBreakpoint = () => {
       setBreakpoint({
-        isMobile: mediaQueryLists.mobile.matches,
-        isTablet: mediaQueryLists.tablet.matches,
-        isDesktop: mediaQueryLists.desktop.matches,
+        isMobileSize: mediaQueryLists.mobile.matches,
+        isTabletSize: mediaQueryLists.tablet.matches,
+        isDesktopSize: mediaQueryLists.desktop.matches,
       });
     };
 

--- a/apps/web/src/shared/hooks/useDebounce.ts
+++ b/apps/web/src/shared/hooks/useDebounce.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * 값의 변경을 지연시키는 Debounce 커스텀 훅
+ * @param value 디바운싱할 값
+ * @param delay 지연 시간 (밀리초 단위)
+ * @returns 디바운싱된 값
+ */
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(
+    () => {
+      const handler = setTimeout(() => {
+        setDebouncedValue(value);
+      }, delay);
+      // 사용자가 delay 시간 내에 계속 타이핑하면 이전 타이머는 취소되고 새 타이머가 설정됩니다.
+      return () => {
+        clearTimeout(handler);
+      };
+    },
+    [value, delay], // value 또는 delay가 변경될 때만 이 effect를 다시 실행합니다.
+  );
+
+  return debouncedValue;
+}

--- a/apps/web/src/shared/hooks/useInfiniteScroll.ts
+++ b/apps/web/src/shared/hooks/useInfiniteScroll.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+interface useInfiniteScrollProps {
+  intersectionCallback: IntersectionObserverCallback;
+  option?: IntersectionObserverInit;
+}
+
+export const useInfiniteScroll = ({
+  intersectionCallback,
+  option,
+}: useInfiniteScrollProps) => {
+  const targetRef = useRef<HTMLDivElement | null>(null);
+
+  const observerOption = option || {
+    root: null,
+    rootMargin: '0px',
+    threshold: 0.1,
+  };
+
+  useEffect(() => {
+    if (!targetRef.current) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      intersectionCallback,
+      observerOption,
+    );
+
+    observer.observe(targetRef.current);
+
+    return () => {
+      if (targetRef.current) {
+        observer.disconnect();
+      }
+    };
+  }, [intersectionCallback]);
+
+  return { targetRef };
+};

--- a/apps/web/src/shared/hooks/useInfiniteScroll.ts
+++ b/apps/web/src/shared/hooks/useInfiniteScroll.ts
@@ -1,8 +1,8 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
-interface useInfiniteScrollProps {
+interface UseInfiniteScrollProps {
   intersectionCallback: IntersectionObserverCallback;
   option?: IntersectionObserverInit;
 }
@@ -10,14 +10,18 @@ interface useInfiniteScrollProps {
 export const useInfiniteScroll = ({
   intersectionCallback,
   option,
-}: useInfiniteScrollProps) => {
+}: UseInfiniteScrollProps) => {
   const targetRef = useRef<HTMLDivElement | null>(null);
 
-  const observerOption = option || {
-    root: null,
-    rootMargin: '0px',
-    threshold: 0.1,
-  };
+  const observerOption = useMemo<IntersectionObserverInit>(
+    () =>
+      option ?? {
+        root: null,
+        rootMargin: '0px',
+        threshold: 0.1,
+      },
+    [option],
+  );
 
   useEffect(() => {
     if (!targetRef.current) {
@@ -32,11 +36,9 @@ export const useInfiniteScroll = ({
     observer.observe(targetRef.current);
 
     return () => {
-      if (targetRef.current) {
-        observer.disconnect();
-      }
+      observer.disconnect();
     };
-  }, [intersectionCallback]);
+  }, [intersectionCallback, observerOption]);
 
   return { targetRef };
 };

--- a/apps/web/src/shared/index.ts
+++ b/apps/web/src/shared/index.ts
@@ -1,2 +1,3 @@
 export * from './ui';
 export * from './constants';
+export * from './hooks';


### PR DESCRIPTION
# 🚀 Pull Request

## Issue

- Closes #40

## ✨ Summary

기존 v2 레포에서 사용하던 공용 훅을 마이그레이션 하고, 
반응형 대응을 위한 훅을 신규 구현했습니다.

## 📚 Details of Changes

- useDebounce, useInfiniteScroll 마이그레이션
- useBreakpoint 훅 구현: `matchMedia` 기반으로 breakpoint 변경 감지하여 `isMobile`, `isTablet`, `isDesktop` boolean 값 제공

```ts
export const MEDIA_QUERIES = {
  mobile: '(max-width: 767px)',
  tablet: '(min-width: 768px) and (max-width: 1199px)',
  desktop: '(min-width: 1200px)',
} as const;
```

## 🎯 Key points to review

- `useBreakpoint` 구현 시 Next.js 환경(SSR)을 고려해 `matchMedia` 기반으로 작성했습니다.  테스트에서는 정상적으로 잘 동작하지만, 해당 방식이 적절한지 혹은 보완이 필요한 부분이 있는지 리뷰 부탁드립니다.

## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

## 📎 Additional Notes
-
