### PR TITLE
[FEAT/#63] 앱 내의 웹뷰 호스팅 상황에서 statusbar상단 바 homeindicator 하단 바 공간 분리

### DIFF
--- a/apps/web/android/app/src/main/java/kr/co/causwv3/twa/MainActivity.java
+++ b/apps/web/android/app/src/main/java/kr/co/causwv3/twa/MainActivity.java
@@ -6,8 +6,15 @@ package kr.co.causwv3.twa;
 import android.os.Bundle;
 import android.os.Handler;
 import android.util.Log; // ⭐️ 추가
+import android.view.View;
+import android.view.ViewGroup;
 import android.webkit.WebView;
 import android.widget.Toast;
+
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowCompat;
 
 import com.getcapacitor.BridgeActivity;
 import com.google.firebase.messaging.FirebaseMessaging; // ⭐️ 추가
@@ -30,6 +37,8 @@ public class MainActivity extends BridgeActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+        setupNativeSafeAreaInsets();
 
         // ⭐️ FCM 토큰을 가져와서 로그에 출력하는 코드
         FirebaseMessaging.getInstance().getToken()
@@ -41,7 +50,7 @@ public class MainActivity extends BridgeActivity {
 
                 // 새로운 FCM 토큰 가져오기 성공
                 String token = task.getResult();
-                
+
                 // 📍 Logcat에서 'FCM_TEST' 또는 'FCM 토큰'으로 검색하세요!
                 System.out.println("📍 [FCM 토큰]: " + token);
                 Log.d(TAG, "📍 [FCM 토큰]: " + token);
@@ -51,6 +60,47 @@ public class MainActivity extends BridgeActivity {
         if (webView != null) {
             webView.getSettings().setTextZoom(100);
         }
+    }
+
+    private void setupNativeSafeAreaInsets() {
+        View rootView = findViewById(android.R.id.content);
+        if (rootView == null) {
+            return;
+        }
+
+        ViewCompat.setOnApplyWindowInsetsListener(rootView, (view, windowInsets) -> {
+            Insets insets = windowInsets.getInsets(
+                WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout()
+            );
+            applyInsetsToWebViewFrame(insets);
+            return windowInsets;
+        });
+
+        ViewCompat.requestApplyInsets(rootView);
+    }
+
+    private void applyInsetsToWebViewFrame(Insets insets) {
+        WebView webView = getBridge() != null ? getBridge().getWebView() : null;
+        if (webView == null) {
+            return;
+        }
+
+        ViewGroup.LayoutParams lp = webView.getLayoutParams();
+        if (!(lp instanceof ViewGroup.MarginLayoutParams)) {
+            webView.setPadding(insets.left, insets.top, insets.right, insets.bottom);
+            return;
+        }
+
+        ViewGroup.MarginLayoutParams marginLp = (ViewGroup.MarginLayoutParams) lp;
+        if (marginLp.leftMargin == insets.left
+            && marginLp.topMargin == insets.top
+            && marginLp.rightMargin == insets.right
+            && marginLp.bottomMargin == insets.bottom) {
+            return;
+        }
+
+        marginLp.setMargins(insets.left, insets.top, insets.right, insets.bottom);
+        webView.setLayoutParams(marginLp);
     }
 
     @Override

--- a/apps/web/android/app/src/main/java/kr/co/causwv3/twa/MainActivity.java
+++ b/apps/web/android/app/src/main/java/kr/co/causwv3/twa/MainActivity.java
@@ -10,7 +10,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.WebView;
 import android.widget.Toast;
-
+import androidx.core.view.WindowInsetsControllerCompat;
 import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
@@ -38,6 +38,10 @@ public class MainActivity extends BridgeActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+
+        WindowInsetsControllerCompat controller = WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
+        controller.setAppearanceLightStatusBars(true); // 상태바 아이콘 검정색
+        controller.setAppearanceLightNavigationBars(true); // 네비게이션바(홈버튼) 아이콘 검정색
         setupNativeSafeAreaInsets();
 
         // ⭐️ FCM 토큰을 가져와서 로그에 출력하는 코드

--- a/apps/web/android/app/src/main/res/values/styles.xml
+++ b/apps/web/android/app/src/main/res/values/styles.xml
@@ -12,11 +12,14 @@
     <style name="AppTheme.NoActionBar" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
-        <item name="android:background">@null</item>
+        <item name="android:background">@android:color/white</item>
+        <item name="android:statusBarColor">@android:color/white</item>
+        <item name="android:navigationBarColor">@android:color/white</item>
     </style>
 
 
     <style name="AppTheme.NoActionBarLaunch" parent="Theme.SplashScreen">
         <item name="android:background">@drawable/splash</item>
+        <item name="postSplashScreenTheme">@style/AppTheme.NoActionBar</item>
     </style>
 </resources>

--- a/apps/web/capacitor.config.ts
+++ b/apps/web/capacitor.config.ts
@@ -24,7 +24,7 @@ const config: CapacitorConfig = {
     StatusBar: {
       style: 'LIGHT_CONTENT',
       backgroundColor: '#ffffff',
-      overlaysWebView: false,
+      overlaysWebView: true,
     },
     PushNotifications: {
       presentationOptions: ['badge', 'sound', 'alert'],

--- a/apps/web/ios/App/App/AppDelegate.swift
+++ b/apps/web/ios/App/App/AppDelegate.swift
@@ -8,6 +8,13 @@ import UserNotifications
 class AppDelegate: UIResponder, UIApplicationDelegate,UNUserNotificationCenterDelegate {
 
     var window: UIWindow?
+    private var didDetachWebViewConstraints = false
+    private var safeAreaRecalcWorkItem: DispatchWorkItem?
+
+    private struct SafeAreaSnapshot: Equatable {
+        let size: CGSize
+        let origin: CGPoint
+    }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
@@ -16,43 +23,141 @@ class AppDelegate: UIResponder, UIApplicationDelegate,UNUserNotificationCenterDe
         
         //이 문장이 있어야 'didRegisterForRemoteNotifications~~'가 호출됨 
         application.registerForRemoteNotifications()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleDeviceOrientationDidChange),
+            name: UIDevice.orientationDidChangeNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+        UIDevice.current.beginGeneratingDeviceOrientationNotifications()
         DispatchQueue.main.async {
-            guard let bridgeViewController = self.window?.rootViewController as? CAPBridgeViewController else {
-                return
-            }
-            
-            if let webView = bridgeViewController.webView {
-                webView.allowsBackForwardNavigationGestures = true
-                
-                // 1. [수정] 스크롤 뷰가 자동으로 Safe Area 인셋을 계산하도록 설정 (가장 중요)
-                // .never를 .always 또는 .automatic으로 변경하면 시스템이 Safe Area만큼 여백을 줍니다.
-                webView.scrollView.contentInsetAdjustmentBehavior = .never
-                
-                // 2. [추가] 웹뷰의 프레임 자체를 Safe Area에 맞추기 (선택 사항)
-                // Capacitor는 기본적으로 전체 화면을 잡으므로, 강제로 Safe Area에 맞추고 싶다면 아래 로직을 사용합니다.
-                if let window = self.window {
-                    let safeAreaInsets = window.safeAreaInsets
-                    
-                    window.backgroundColor = .white
-                    bridgeViewController.view.backgroundColor = .white
-                    let newFrame = CGRect(
-                        x: safeAreaInsets.left,
-                        y: safeAreaInsets.top,
-                        width: window.frame.width - safeAreaInsets.left - safeAreaInsets.right,
-                        height: window.frame.height - safeAreaInsets.top - safeAreaInsets.bottom
-                    )
-                    webView.frame = newFrame
-                }
-                
-                // 3. 배경색 설정 (Safe Area 밖의 여백 색상을 결정함)
-                webView.isOpaque = true // 투명하게 하면 뒤의 빈 공간이 보일 수 있으므로 배경색을 주는 것이 깔끔합니다.
-                webView.backgroundColor = .white
-                // 혹은 앱의 주 테마 색상
-                webView.scrollView.backgroundColor = .white
-                
-            }
+            self.configureBridgeWebView()
+            self.startSafeAreaRecalculationCycle()
         }
         return true
+    }
+
+    @objc private func handleDeviceOrientationDidChange() {
+        let orientation = UIDevice.current.orientation
+        if isUnsupportedUpsideDownEvent(orientation) {
+            return
+        }
+        startSafeAreaRecalculationCycle()
+    }
+
+    @objc private func handleDidBecomeActive() {
+        startSafeAreaRecalculationCycle()
+    }
+
+    private func configureBridgeWebView() {
+        guard let bridgeViewController = self.window?.rootViewController as? CAPBridgeViewController,
+              let webView = bridgeViewController.webView else {
+            return
+        }
+
+        window?.backgroundColor = .white
+        bridgeViewController.view.backgroundColor = .white
+        webView.allowsBackForwardNavigationGestures = true
+        webView.scrollView.contentInsetAdjustmentBehavior = .never
+        webView.isOpaque = true
+        webView.backgroundColor = .white
+        webView.scrollView.backgroundColor = .white
+        webView.translatesAutoresizingMaskIntoConstraints = true
+        webView.autoresizingMask = []
+        webView.alpha = 0
+
+        if !didDetachWebViewConstraints {
+            detachWebViewConstraints(webView)
+            didDetachWebViewConstraints = true
+        }
+    }
+
+    private func startSafeAreaRecalculationCycle() {
+        safeAreaRecalcWorkItem?.cancel()
+        setBridgeWebViewVisible(false)
+        recalculateSafeAreaUntilStable(remainingAttempts: 40, lastSnapshot: nil, stableCount: 0)
+    }
+
+    private func recalculateSafeAreaUntilStable(
+        remainingAttempts: Int,
+        lastSnapshot: SafeAreaSnapshot?,
+        stableCount: Int
+    ) {
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            guard let bridgeViewController = self.window?.rootViewController as? CAPBridgeViewController,
+                  let webView = bridgeViewController.webView else {
+                return
+            }
+
+            bridgeViewController.view.layoutIfNeeded()
+            let safeFrameInBridge = bridgeViewController.view.safeAreaLayoutGuide.layoutFrame
+
+            let hasValidBounds = safeFrameInBridge.width > 0 && safeFrameInBridge.height > 0
+            let snapshot = SafeAreaSnapshot(
+                size: safeFrameInBridge.size,
+                origin: safeFrameInBridge.origin
+            )
+
+            let nextStableCount = (snapshot == lastSnapshot) ? (stableCount + 1) : 1
+            if hasValidBounds && nextStableCount >= 3 {
+                webView.frame = safeFrameInBridge
+                self.setBridgeWebViewVisible(true)
+                return
+            }
+
+            if remainingAttempts <= 0 {
+                if hasValidBounds {
+                    webView.frame = safeFrameInBridge
+                }
+                self.setBridgeWebViewVisible(true)
+                return
+            }
+
+            self.recalculateSafeAreaUntilStable(
+                remainingAttempts: remainingAttempts - 1,
+                lastSnapshot: snapshot,
+                stableCount: nextStableCount
+            )
+        }
+
+        safeAreaRecalcWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.06, execute: workItem)
+    }
+
+    private func isUnsupportedUpsideDownEvent(_ orientation: UIDeviceOrientation) -> Bool {
+        guard orientation == .portraitUpsideDown else { return false }
+        guard UIDevice.current.userInterfaceIdiom == .phone else { return false }
+        return !isInterfaceOrientationSupported("UIInterfaceOrientationPortraitUpsideDown")
+    }
+
+    private func isInterfaceOrientationSupported(_ orientationValue: String) -> Bool {
+        guard let values = Bundle.main.object(forInfoDictionaryKey: "UISupportedInterfaceOrientations") as? [String] else {
+            return true
+        }
+        return values.contains(orientationValue)
+    }
+
+    private func setBridgeWebViewVisible(_ visible: Bool) {
+        guard let bridgeViewController = self.window?.rootViewController as? CAPBridgeViewController,
+              let webView = bridgeViewController.webView else {
+            return
+        }
+        webView.alpha = visible ? 1 : 0
+    }
+
+    private func detachWebViewConstraints(_ webView: UIView) {
+        guard let superview = webView.superview else { return }
+        let relatedConstraints = superview.constraints.filter { constraint in
+            (constraint.firstItem as? UIView) == webView || (constraint.secondItem as? UIView) == webView
+        }
+        NSLayoutConstraint.deactivate(relatedConstraints)
     }
     
     
@@ -117,6 +222,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate,UNUserNotificationCenterDe
 
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+        safeAreaRecalcWorkItem?.cancel()
+        UIDevice.current.endGeneratingDeviceOrientationNotifications()
+        NotificationCenter.default.removeObserver(self)
     }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {

--- a/apps/web/ios/App/App/AppDelegate.swift
+++ b/apps/web/ios/App/App/AppDelegate.swift
@@ -17,16 +17,45 @@ class AppDelegate: UIResponder, UIApplicationDelegate,UNUserNotificationCenterDe
         //이 문장이 있어야 'didRegisterForRemoteNotifications~~'가 호출됨 
         application.registerForRemoteNotifications()
         DispatchQueue.main.async {
-                   guard let bridgeViewController = self.window?.rootViewController as? CAPBridgeViewController else {
-                       return
-                   }
-
-                   if let webView = bridgeViewController.webView {
-                       webView.allowsBackForwardNavigationGestures = true
-                   }
-               }
+            guard let bridgeViewController = self.window?.rootViewController as? CAPBridgeViewController else {
+                return
+            }
+            
+            if let webView = bridgeViewController.webView {
+                webView.allowsBackForwardNavigationGestures = true
+                
+                // 1. [수정] 스크롤 뷰가 자동으로 Safe Area 인셋을 계산하도록 설정 (가장 중요)
+                // .never를 .always 또는 .automatic으로 변경하면 시스템이 Safe Area만큼 여백을 줍니다.
+                webView.scrollView.contentInsetAdjustmentBehavior = .never
+                
+                // 2. [추가] 웹뷰의 프레임 자체를 Safe Area에 맞추기 (선택 사항)
+                // Capacitor는 기본적으로 전체 화면을 잡으므로, 강제로 Safe Area에 맞추고 싶다면 아래 로직을 사용합니다.
+                if let window = self.window {
+                    let safeAreaInsets = window.safeAreaInsets
+                    
+                    window.backgroundColor = .white
+                    bridgeViewController.view.backgroundColor = .white
+                    let newFrame = CGRect(
+                        x: safeAreaInsets.left,
+                        y: safeAreaInsets.top,
+                        width: window.frame.width - safeAreaInsets.left - safeAreaInsets.right,
+                        height: window.frame.height - safeAreaInsets.top - safeAreaInsets.bottom
+                    )
+                    webView.frame = newFrame
+                }
+                
+                // 3. 배경색 설정 (Safe Area 밖의 여백 색상을 결정함)
+                webView.isOpaque = true // 투명하게 하면 뒤의 빈 공간이 보일 수 있으므로 배경색을 주는 것이 깔끔합니다.
+                webView.backgroundColor = .white
+                // 혹은 앱의 주 테마 색상
+                webView.scrollView.backgroundColor = .white
+                
+            }
+        }
         return true
     }
+    
+    
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
             
             //  알림이 잘 왔는지 확인하는 로그


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #63 


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- statusBar와 homeIndicator 공간의 분리


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- ios : swift 코드 내에서 웹뷰 호스팅 시 safe-inset 고려하여 웹뷰 렌더링
- android : xml, java 코드 내에서 웹뷰 호스팅 시 safe-inset 고려하여 웹뷰 렌더링 


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- 테스트 위주로 잘 되는지만 파악 부탁드립니다


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.


## 📎 Additional Notes
android, ios 테스트 화면입니다

<img width="448" height="943" alt="ios safe area" src="https://github.com/user-attachments/assets/8602928f-4f34-492b-8843-0e99c08ce35f" />
<img width="406" height="929" alt="android safe area" src="https://github.com/user-attachments/assets/f922ce8b-2614-4614-9b01-4115bef167a6" />

ios 회전 테스트 화면입니다. ( and는 정상적으로 작동해서 pass )


https://github.com/user-attachments/assets/e4d413e5-ba08-445d-a1a8-1abbff34c954

https://github.com/user-attachments/assets/7c03fecc-97af-4960-a2ff-360851e8cde3



