### PR TITLE
[FEAT/#66] 인증 관련 라우팅 처리 provider 추가

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },
+  "todo-tree.filtering.excludeGlobs": ["**/node_modules/**"],
   "eslint.validate": [
     "javascript",
     "javascriptreact",

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -4,6 +4,8 @@ import { useEffect } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
 
+import { captureSentry } from '@causw/logger';
+
 import { AuthError } from '@/shared/model';
 
 import { ErrorView } from '@/shared';
@@ -21,7 +23,10 @@ export default function ErrorPage({
     if (error instanceof AuthError) {
       return;
     }
-    reportError(error);
+    captureSentry(error, 'unexpected_error', {
+      info: '루트 레이아웃에서 에러 발생',
+      digest: error.digest,
+    });
   }, [error]);
 
   const handleReset = () => {

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -4,6 +4,8 @@ import { useEffect } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
 
+import { AuthError } from '@/shared/model';
+
 import { ErrorView } from '@/shared';
 
 export default function ErrorPage({
@@ -16,7 +18,10 @@ export default function ErrorPage({
   const queryClient = useQueryClient();
 
   useEffect(() => {
-    console.error(error);
+    if (error instanceof AuthError) {
+      return;
+    }
+    reportError(error);
   }, [error]);
 
   const handleReset = () => {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from 'next';
 
 import { getTraceData } from '@causw/logger';
 
-import { QueryProviderWithDevtools } from '@/shared';
+import { GlobalRoutingProvider, QueryProviderWithDevtools } from '@/shared';
 
 export const metadata: Metadata = {
   title: '동문 네트워크',
@@ -22,7 +22,9 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className={`antialiased`}>
-        <QueryProviderWithDevtools>{children}</QueryProviderWithDevtools>
+        <QueryProviderWithDevtools>
+          <GlobalRoutingProvider>{children}</GlobalRoutingProvider>
+        </QueryProviderWithDevtools>
       </body>
     </html>
   );

--- a/apps/web/src/shared/api/interceptors/request/requestInterceptor.ts
+++ b/apps/web/src/shared/api/interceptors/request/requestInterceptor.ts
@@ -1,4 +1,4 @@
-import { useAuthStore } from '@/shared/model';
+import { useAuthStore, AuthError } from '@/shared/model';
 import { TokenManager } from '@/shared/storage/auth';
 import { isServer } from '@/shared/utils';
 
@@ -13,12 +13,12 @@ export const setRequestInterceptors = (apiClient: BaseApiClient) => {
     const accessToken = await TokenManager.getAccessToken();
 
     if (!refreshToken && !accessToken) {
-      useAuthStore.getState().setAuthError({
-        code: 'token-expired',
-        message: '토큰이 만료되었습니다. 다시 로그인해주세요.',
-      });
-      // TODO: 인증 관련 에러 클래스 만들어서 throw (layout 단에서는 sentry report X)
-      throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
+      const newError = new AuthError(
+        'token-expired',
+        '토큰이 만료되었습니다. 다시 로그인해주세요.',
+      );
+      useAuthStore.getState().setAuthError(newError);
+      throw newError;
     }
 
     // 토큰 주입

--- a/apps/web/src/shared/api/interceptors/request/requestInterceptor.ts
+++ b/apps/web/src/shared/api/interceptors/request/requestInterceptor.ts
@@ -13,6 +13,7 @@ export const setRequestInterceptors = (apiClient: BaseApiClient) => {
     const accessToken = await TokenManager.getAccessToken();
 
     if (!refreshToken && !accessToken) {
+      // TODO: 토큰 활용하지 않는 api의 경우 public 경로로 분리하여 분기 로직 추가
       const newError = new AuthError(
         'token-expired',
         '토큰이 만료되었습니다. 다시 로그인해주세요.',

--- a/apps/web/src/shared/api/interceptors/request/requestInterceptor.ts
+++ b/apps/web/src/shared/api/interceptors/request/requestInterceptor.ts
@@ -1,3 +1,4 @@
+import { useAuthStore } from '@/shared/model';
 import { TokenManager } from '@/shared/storage/auth';
 import { isServer } from '@/shared/utils';
 
@@ -8,8 +9,19 @@ export const setRequestInterceptors = (apiClient: BaseApiClient) => {
     const headers: Record<string, string> = {};
     let nextOptions: NextFetchRequestConfig = {};
 
-    // 토큰 주입
+    const refreshToken = await TokenManager.getRefreshToken();
     const accessToken = await TokenManager.getAccessToken();
+
+    if (!refreshToken && !accessToken) {
+      useAuthStore.getState().setAuthError({
+        code: 'token-expired',
+        message: '토큰이 만료되었습니다. 다시 로그인해주세요.',
+      });
+      // TODO: 인증 관련 에러 클래스 만들어서 throw (layout 단에서는 sentry report X)
+      throw new Error('토큰이 만료되었습니다. 다시 로그인해주세요.');
+    }
+
+    // 토큰 주입
     if (accessToken) {
       headers.Authorization = `Bearer ${accessToken}`;
     }

--- a/apps/web/src/shared/api/interceptors/response/responseInterceptor.ts
+++ b/apps/web/src/shared/api/interceptors/response/responseInterceptor.ts
@@ -1,6 +1,7 @@
 import { ApiResponse, isApiError } from '@causw/api-client';
 import { reportApiError } from '@causw/logger';
 
+import { useAuthStore } from '@/shared/model';
 import { TokenManager } from '@/shared/storage/auth';
 import {
   isAccessTokenError,
@@ -81,7 +82,10 @@ export const setResponseInterceptors = (apiWrapper: BaseApiClient) => {
           apiWrapper.rejectRefreshQueue();
           await TokenManager.removeAccessToken();
           await TokenManager.removeRefreshToken();
-          // TODO: 라우팅 로직
+          useAuthStore.getState().setAuthError({
+            code: 'token-expired',
+            message: '토큰이 만료되었습니다. 다시 로그인해주세요.',
+          });
           throw refreshError;
         } finally {
           apiWrapper.setIsRefreshing(false);

--- a/apps/web/src/shared/api/interceptors/response/responseInterceptor.ts
+++ b/apps/web/src/shared/api/interceptors/response/responseInterceptor.ts
@@ -1,7 +1,7 @@
 import { ApiResponse, isApiError } from '@causw/api-client';
 import { reportApiError } from '@causw/logger';
 
-import { useAuthStore } from '@/shared/model';
+import { useAuthStore, AuthError } from '@/shared/model';
 import { TokenManager } from '@/shared/storage/auth';
 import {
   isAccessTokenError,
@@ -82,11 +82,14 @@ export const setResponseInterceptors = (apiWrapper: BaseApiClient) => {
           apiWrapper.rejectRefreshQueue();
           await TokenManager.removeAccessToken();
           await TokenManager.removeRefreshToken();
-          useAuthStore.getState().setAuthError({
-            code: 'token-expired',
-            message: '토큰이 만료되었습니다. 다시 로그인해주세요.',
-          });
-          throw refreshError;
+
+          const newError = new AuthError(
+            'token-expired',
+            '토큰이 만료되었습니다. 다시 로그인해주세요.',
+            { cause: refreshError },
+          );
+          useAuthStore.getState().setAuthError(newError);
+          throw newError;
         } finally {
           apiWrapper.setIsRefreshing(false);
         }

--- a/apps/web/src/shared/model/auth/authStore.ts
+++ b/apps/web/src/shared/model/auth/authStore.ts
@@ -1,0 +1,20 @@
+import { create } from 'zustand';
+
+type AuthErrorType = 'token-expired' | 'no-permission';
+
+type AuthError = {
+  code: AuthErrorType;
+  message: string;
+};
+
+type AuthStore = {
+  authError: AuthError | null;
+  setAuthError: (error: AuthError) => void;
+  clearAuthError: () => void;
+};
+
+export const useAuthStore = create<AuthStore>((set) => ({
+  authError: null,
+  setAuthError: (error) => set({ authError: error }),
+  clearAuthError: () => set({ authError: null }),
+}));

--- a/apps/web/src/shared/model/auth/authStore.ts
+++ b/apps/web/src/shared/model/auth/authStore.ts
@@ -2,10 +2,20 @@ import { create } from 'zustand';
 
 type AuthErrorType = 'token-expired' | 'no-permission';
 
-type AuthError = {
-  code: AuthErrorType;
+export class AuthError extends Error {
+  errorType: AuthErrorType;
   message: string;
-};
+
+  constructor(
+    errorType: AuthErrorType,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.errorType = errorType;
+    this.message = message;
+  }
+}
 
 type AuthStore = {
   authError: AuthError | null;

--- a/apps/web/src/shared/model/auth/index.ts
+++ b/apps/web/src/shared/model/auth/index.ts
@@ -1,0 +1,1 @@
+export { useAuthStore } from './authStore';

--- a/apps/web/src/shared/model/auth/index.ts
+++ b/apps/web/src/shared/model/auth/index.ts
@@ -1,1 +1,1 @@
-export { useAuthStore } from './authStore';
+export { useAuthStore, AuthError } from './authStore';

--- a/apps/web/src/shared/model/index.ts
+++ b/apps/web/src/shared/model/index.ts
@@ -1,1 +1,2 @@
 export * from './form/schema';
+export * from './auth';

--- a/apps/web/src/shared/ui/provider/global-routing/GlobalRoutingProvider.tsx
+++ b/apps/web/src/shared/ui/provider/global-routing/GlobalRoutingProvider.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect } from 'react';
+import type { ReactNode } from 'react';
+
+import { usePathname, useRouter } from 'next/navigation';
+
+import { useAuthStore } from '@/shared/model';
+
+type ProviderProps = {
+  children: ReactNode;
+};
+
+export function GlobalRoutingProvider({ children }: ProviderProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const authError = useAuthStore((state) => state.authError);
+  const clearAuthError = useAuthStore((state) => state.clearAuthError);
+
+  useEffect(() => {
+    if (!authError) return;
+
+    if (authError.code === 'token-expired') {
+      alert(authError.message);
+
+      // TODO: 로그인 시 callbackUrl 활용한 라우팅 추가
+      const callbackUrl = encodeURIComponent(pathname ?? '/');
+      router.push(`/auth/sign-in?callbackUrl=${callbackUrl}`);
+    }
+
+    clearAuthError();
+  }, [authError, router, pathname, clearAuthError]);
+
+  return <>{children}</>;
+}

--- a/apps/web/src/shared/ui/provider/global-routing/GlobalRoutingProvider.tsx
+++ b/apps/web/src/shared/ui/provider/global-routing/GlobalRoutingProvider.tsx
@@ -20,7 +20,7 @@ export function GlobalRoutingProvider({ children }: ProviderProps) {
   useEffect(() => {
     if (!authError) return;
 
-    if (authError.code === 'token-expired') {
+    if (authError.errorType === 'token-expired') {
       alert(authError.message);
 
       // TODO: 로그인 시 callbackUrl 활용한 라우팅 추가

--- a/apps/web/src/shared/ui/provider/global-routing/index.ts
+++ b/apps/web/src/shared/ui/provider/global-routing/index.ts
@@ -1,0 +1,1 @@
+export { GlobalRoutingProvider } from './GlobalRoutingProvider';

--- a/apps/web/src/shared/ui/provider/index.ts
+++ b/apps/web/src/shared/ui/provider/index.ts
@@ -2,3 +2,4 @@ export {
   QueryErrorBoundary,
   QueryProviderWithDevtools,
 } from './tanstack-query';
+export { GlobalRoutingProvider } from './global-routing';

--- a/packages/api-client/src/core/ApiClient.ts
+++ b/packages/api-client/src/core/ApiClient.ts
@@ -88,12 +88,35 @@ export class ApiClient {
         signal: controller.signal,
       });
     } catch (error) {
+      const errorOptions = { cause: error };
+
       if (error instanceof DOMException && error.name === 'AbortError') {
-        throw new ApiError('Request Timeout', config, 'ECONNABORTED', null);
+        throw new ApiError(
+          'Request Timeout',
+          config,
+          'ECONNABORTED',
+          null,
+          undefined,
+          errorOptions,
+        );
       } else if (error instanceof TypeError) {
-        throw new ApiError('Network Error', config, 'ERR_NETWORK', null);
+        throw new ApiError(
+          'Network Error',
+          config,
+          'ERR_NETWORK',
+          null,
+          undefined,
+          errorOptions,
+        );
       } else {
-        throw new ApiError('Unknown Error', config, 'UNKNOWN', null);
+        throw new ApiError(
+          'Unknown Error',
+          config,
+          'UNKNOWN',
+          null,
+          undefined,
+          errorOptions,
+        );
       }
     } finally {
       clearTimeout(timeoutId);
@@ -143,6 +166,7 @@ export class ApiClient {
         response.status.toString(),
         null,
         apiResponse,
+        { cause: apiResponse },
       );
       promise = Promise.reject(error);
     }

--- a/packages/api-client/src/errors/ApiError.ts
+++ b/packages/api-client/src/errors/ApiError.ts
@@ -15,8 +15,9 @@ export class ApiError<T = any> extends Error {
     code?: string,
     request?: any,
     response?: ApiResponse<T>,
+    options?: ErrorOptions,
   ) {
-    super(message);
+    super(message, options);
     this.name = 'ApiError';
     this.config = config;
     this.code = code;


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #66 


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 인증 관련 라우팅 처리 provider 추가


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

[ packages/api-client ]
- 기존의 ErrorOption 타입에서의 cause 속성 누락되어서 전달되는 이슈 핸들링

[ apps/web ]
- GlobalRoutingProvider로 인증 관련 라우팅 로직 분리 ( 레이아웃 단에서 authStore 구독 )
- authStore에서 인증 관련 상태관리 담당
- authError 클래스로 구조화
- req, res interceptor 단에서 authStore 상태 변경
- 루트 레이아웃 단에서 authError 인스턴스 판별 로직 및 에러 로깅 추가 

## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.
 
- @gomx3  루트에서의 error.tsx에서도 로깅을 하는게 좋지 않을까 생각해서 추가해봤습니다. 예를 들어서 서버 컴포넌트에서 데이터는 제대로 페칭이 되어서 api response 상으로 에러가 오지는 않았는데 타입이나 형식이 달라 렌더링 도중 에러가 발생하면 error.tsx에서만 잡을 수 있을 것 같습니다.


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.


## 📎 Additional Notes
-
