### PR TITLE
[FEAT/#94] 모바일 환경에서의 소셜 로그인 구현

### DIFF
--- a/apps/web/android/.idea/deploymentTargetSelector.xml
+++ b/apps/web/android/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,14 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2026-02-26T20:19:37.190631Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/younghyunkim/.android/avd/Pixel_4.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/apps/web/android/app/build.gradle
+++ b/apps/web/android/app/build.gradle
@@ -33,6 +33,7 @@ repositories {
 dependencies {
     implementation platform('com.google.firebase:firebase-bom:33.1.2')
     implementation 'com.google.firebase:firebase-messaging'
+    implementation 'com.kakao.sdk:v2-user:2.11.0'
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"

--- a/apps/web/android/app/build.gradle
+++ b/apps/web/android/app/build.gradle
@@ -33,6 +33,7 @@ repositories {
 dependencies {
     implementation platform('com.google.firebase:firebase-bom:33.1.2')
     implementation 'com.google.firebase:firebase-messaging'
+    implementation 'com.google.android.gms:play-services-auth:21.2.0'
     implementation 'com.kakao.sdk:v2-user:2.11.0'
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"

--- a/apps/web/android/app/src/main/AndroidManifest.xml
+++ b/apps/web/android/app/src/main/AndroidManifest.xml
@@ -23,7 +23,19 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-
+        </activity>
+        
+        <activity
+            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="kakao4535709d7c684cff31a42bb2b522eed9"
+                    android:host="oauth" />
+            </intent-filter>
         </activity>
 
         <provider

--- a/apps/web/android/app/src/main/java/kr/co/causwv2/twa/BackPressHandler.java
+++ b/apps/web/android/app/src/main/java/kr/co/causwv2/twa/BackPressHandler.java
@@ -1,0 +1,47 @@
+package kr.co.causwv2.twa;
+
+import android.app.Activity;
+import android.os.Handler;
+import android.widget.Toast;
+import android.webkit.WebView;
+
+final class BackPressHandler {
+    private static final int BACK_PRESS_TIMEOUT = 2000;
+
+    private final Activity activity;
+    private final WebView webView;
+    private final Handler handler = new Handler();
+
+    private boolean backPressedOnce = false;
+    private final Runnable resetBackPress = new Runnable() {
+        @Override
+        public void run() {
+            backPressedOnce = false;
+        }
+    };
+
+    BackPressHandler(Activity activity, WebView webView) {
+        this.activity = activity;
+        this.webView = webView;
+    }
+
+    void handleBackPress() {
+        if (webView != null && webView.canGoBack()) {
+            activity.onBackPressed();
+            return;
+        }
+
+        if (backPressedOnce) {
+            activity.finishAffinity();
+            return;
+        }
+
+        backPressedOnce = true;
+        Toast.makeText(activity, "한 번 더 누르면 종료됩니다.", Toast.LENGTH_SHORT).show();
+        handler.postDelayed(resetBackPress, BACK_PRESS_TIMEOUT);
+    }
+
+    void cleanup() {
+        handler.removeCallbacks(resetBackPress);
+    }
+}

--- a/apps/web/android/app/src/main/java/kr/co/causwv2/twa/MainActivity.java
+++ b/apps/web/android/app/src/main/java/kr/co/causwv2/twa/MainActivity.java
@@ -19,6 +19,8 @@ import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowCompat;
 
+import kr.co.causw.R;
+
 import com.getcapacitor.BridgeActivity;
 import com.google.android.gms.auth.api.signin.GoogleSignIn;
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
@@ -44,9 +46,8 @@ public class MainActivity extends BridgeActivity {
     private static final int RC_GOOGLE_SIGN_IN = 9001;
     private static final String TAG = "FCM_TEST"; // ⭐️ 로그 필터용 태그
     private static final String SOCIAL_LOGIN_TAG = "SOCIAL_LOGIN";
-    private static final String KAKAO_NATIVE_APP_KEY = "4535709d7c684cff31a42bb2b522eed9";
-    private static final String GOOGLE_WEB_CLIENT_ID =
-        "1086770319771-hp040om1msg7r4o25u895b1pos47jkjt.apps.googleusercontent.com";
+    private String kakaoNativeAppKey;
+    private String googleWebClientId;
     private String pendingGoogleRequestId = null;
     private GoogleSignInClient googleSignInClient = null;
 
@@ -68,7 +69,9 @@ public class MainActivity extends BridgeActivity {
         controller.setAppearanceLightStatusBars(true); // 상태바 아이콘 검정색
         controller.setAppearanceLightNavigationBars(true); // 네비게이션바(홈버튼) 아이콘 검정색
         setupNativeSafeAreaInsets();
-        KakaoSdk.init(this, KAKAO_NATIVE_APP_KEY);
+        kakaoNativeAppKey = getString(R.string.kakao_native_app_key);
+        googleWebClientId = getString(R.string.google_web_client_id);
+        KakaoSdk.init(this, kakaoNativeAppKey);
         Log.d(SOCIAL_LOGIN_TAG, "Kakao key hash: " + Utility.INSTANCE.getKeyHash(this));
 
         // ⭐️ FCM 토큰을 가져와서 로그에 출력하는 코드
@@ -181,7 +184,7 @@ public class MainActivity extends BridgeActivity {
 
     private void loginWithGoogle(String requestId) {
         Log.d(SOCIAL_LOGIN_TAG, "Google login requested. requestId=" + requestId);
-        if (GOOGLE_WEB_CLIENT_ID == null || GOOGLE_WEB_CLIENT_ID.isEmpty()) {
+        if (googleWebClientId == null || googleWebClientId.isEmpty()) {
             dispatchSocialLoginResult(
                 "google",
                 requestId,
@@ -194,7 +197,7 @@ public class MainActivity extends BridgeActivity {
 
         GoogleSignInOptions options = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
             .requestEmail()
-            .requestIdToken(GOOGLE_WEB_CLIENT_ID)
+            .requestIdToken(googleWebClientId)
             .build();
 
         googleSignInClient = GoogleSignIn.getClient(this, options);
@@ -261,7 +264,7 @@ public class MainActivity extends BridgeActivity {
                     + ", packageName="
                     + getPackageName()
                     + ", webClientId="
-                    + GOOGLE_WEB_CLIENT_ID
+                    + googleWebClientId
                     + ", requestId="
                     + requestId,
                 e
@@ -279,7 +282,7 @@ public class MainActivity extends BridgeActivity {
                 "Google login failed with unexpected error. packageName="
                     + getPackageName()
                     + ", webClientId="
-                    + GOOGLE_WEB_CLIENT_ID
+                    + googleWebClientId
                     + ", requestId="
                     + requestId,
                 e

--- a/apps/web/android/app/src/main/java/kr/co/causwv2/twa/MainActivity.java
+++ b/apps/web/android/app/src/main/java/kr/co/causwv2/twa/MainActivity.java
@@ -8,8 +8,10 @@ import android.os.Handler;
 import android.util.Log; // ⭐️ 추가
 import android.view.View;
 import android.view.ViewGroup;
+import android.webkit.JavascriptInterface;
 import android.webkit.WebView;
 import android.widget.Toast;
+
 import androidx.core.view.WindowInsetsControllerCompat;
 import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
@@ -18,12 +20,24 @@ import androidx.core.view.WindowCompat;
 
 import com.getcapacitor.BridgeActivity;
 import com.google.firebase.messaging.FirebaseMessaging; // ⭐️ 추가
+import com.kakao.sdk.auth.model.OAuthToken;
+import com.kakao.sdk.common.KakaoSdk;
+import com.kakao.sdk.common.util.Utility;
+import com.kakao.sdk.user.UserApiClient;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import kotlin.Unit;
+import kotlin.jvm.functions.Function2;
 
 public class MainActivity extends BridgeActivity {
 
     private boolean backPressedOnce = false;
     private static final int BACK_PRESS_TIMEOUT = 2000;
     private static final String TAG = "FCM_TEST"; // ⭐️ 로그 필터용 태그
+    private static final String SOCIAL_LOGIN_TAG = "SOCIAL_LOGIN";
+    private static final String KAKAO_NATIVE_APP_KEY = "4535709d7c684cff31a42bb2b522eed9";
 
     private final Runnable resetBackPress = new Runnable() {
         @Override
@@ -43,6 +57,8 @@ public class MainActivity extends BridgeActivity {
         controller.setAppearanceLightStatusBars(true); // 상태바 아이콘 검정색
         controller.setAppearanceLightNavigationBars(true); // 네비게이션바(홈버튼) 아이콘 검정색
         setupNativeSafeAreaInsets();
+        KakaoSdk.init(this, KAKAO_NATIVE_APP_KEY);
+        Log.d(SOCIAL_LOGIN_TAG, "Kakao key hash: " + Utility.INSTANCE.getKeyHash(this));
 
         // ⭐️ FCM 토큰을 가져와서 로그에 출력하는 코드
         FirebaseMessaging.getInstance().getToken()
@@ -63,7 +79,127 @@ public class MainActivity extends BridgeActivity {
         WebView webView = getBridge().getWebView();
         if (webView != null) {
             webView.getSettings().setTextZoom(100);
+            SocialLoginBridge bridge = new SocialLoginBridge();
+            webView.addJavascriptInterface(bridge, "AndroidSocialLogin");
+            webView.addJavascriptInterface(bridge, "CauswSocialLoginBridge");
         }
+    }
+
+    private final class SocialLoginBridge {
+        @JavascriptInterface
+        public void requestSocialLogin(String payloadJson) {
+            runOnUiThread(() -> handleSocialLoginRequest(payloadJson));
+        }
+    }
+
+    private void handleSocialLoginRequest(String payloadJson) {
+        final JSONObject payload;
+        try {
+            payload = new JSONObject(payloadJson);
+        } catch (JSONException e) {
+            dispatchSocialLoginResult("kakao", "", null, "INVALID_PAYLOAD", "Invalid JSON payload.");
+            return;
+        }
+
+        String provider = payload.optString("provider", "");
+        String requestId = payload.optString("requestId", "");
+
+        if (provider.isEmpty() || requestId.isEmpty()) {
+            dispatchSocialLoginResult(
+                "kakao",
+                requestId,
+                null,
+                "INVALID_PAYLOAD",
+                "Missing provider or requestId."
+            );
+            return;
+        }
+
+        if (!"kakao".equals(provider)) {
+            dispatchSocialLoginResult(
+                provider,
+                requestId,
+                null,
+                "UNSUPPORTED_PROVIDER",
+                "Unsupported provider on Android bridge."
+            );
+            return;
+        }
+
+        loginWithKakao(requestId);
+    }
+
+    private void loginWithKakao(String requestId) {
+        Function2<OAuthToken, Throwable, Unit> callback = (token, error) -> {
+            if (error != null) {
+                dispatchSocialLoginResult(
+                    "kakao",
+                    requestId,
+                    null,
+                    "KAKAO_LOGIN_FAILED",
+                    error.getMessage()
+                );
+                return Unit.INSTANCE;
+            }
+
+            String accessToken = token != null ? token.getAccessToken() : null;
+            if (accessToken == null || accessToken.isEmpty()) {
+                dispatchSocialLoginResult(
+                    "kakao",
+                    requestId,
+                    null,
+                    "EMPTY_ACCESS_TOKEN",
+                    "Kakao access token is empty."
+                );
+                return Unit.INSTANCE;
+            }
+
+            dispatchSocialLoginResult("kakao", requestId, accessToken, null, null);
+            return Unit.INSTANCE;
+        };
+
+        // 계정 로그인 경로로 고정: 카카오톡 앱 SSO 자동 로그인 분기를 사용하지 않음.
+        UserApiClient.getInstance().loginWithKakaoAccount(this, callback);
+    }
+
+    private void dispatchSocialLoginResult(
+        String provider,
+        String requestId,
+        String accessToken,
+        String errorCode,
+        String message
+    ) {
+        runOnUiThread(() -> {
+            WebView webView = getBridge() != null ? getBridge().getWebView() : null;
+            if (webView == null) {
+                return;
+            }
+
+            JSONObject payload = new JSONObject();
+            try {
+                payload.put("provider", provider);
+                payload.put("requestId", requestId);
+                if (accessToken != null) payload.put("accessToken", accessToken);
+                if (errorCode != null) payload.put("errorCode", errorCode);
+                if (message != null) payload.put("message", message);
+            } catch (JSONException e) {
+                Log.e(SOCIAL_LOGIN_TAG, "Failed to build social login payload", e);
+                return;
+            }
+
+            String payloadLiteral = payload.toString();
+            String callbackScript =
+                "window.__CAUSW_ON_NATIVE_SOCIAL_LOGIN__ && window.__CAUSW_ON_NATIVE_SOCIAL_LOGIN__("
+                    + payloadLiteral
+                    + ");";
+            String eventScript =
+                "window.dispatchEvent(new CustomEvent('causw:social-login-result', { detail: "
+                    + payloadLiteral
+                    + " }));";
+
+            webView.evaluateJavascript(callbackScript, null);
+            webView.evaluateJavascript(eventScript, null);
+        });
     }
 
     private void setupNativeSafeAreaInsets() {

--- a/apps/web/android/app/src/main/java/kr/co/causwv2/twa/MainActivity.java
+++ b/apps/web/android/app/src/main/java/kr/co/causwv2/twa/MainActivity.java
@@ -5,60 +5,29 @@ package kr.co.causwv2.twa;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.Handler;
 import android.util.Log; // ⭐️ 추가
-import android.view.View;
-import android.view.ViewGroup;
-import android.webkit.JavascriptInterface;
 import android.webkit.WebView;
-import android.widget.Toast;
 
 import androidx.core.view.WindowInsetsControllerCompat;
-import androidx.core.graphics.Insets;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowCompat;
 
 import kr.co.causw.R;
 
 import com.getcapacitor.BridgeActivity;
-import com.google.android.gms.auth.api.signin.GoogleSignIn;
-import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
-import com.google.android.gms.auth.api.signin.GoogleSignInClient;
-import com.google.android.gms.auth.api.signin.GoogleSignInOptions;
-import com.google.android.gms.common.api.ApiException;
-import com.google.firebase.messaging.FirebaseMessaging; // ⭐️ 추가
-import com.kakao.sdk.auth.model.OAuthToken;
 import com.kakao.sdk.common.KakaoSdk;
 import com.kakao.sdk.common.util.Utility;
-import com.kakao.sdk.user.UserApiClient;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import kotlin.Unit;
-import kotlin.jvm.functions.Function2;
-
 public class MainActivity extends BridgeActivity {
 
-    private boolean backPressedOnce = false;
-    private static final int BACK_PRESS_TIMEOUT = 2000;
-    private static final int RC_GOOGLE_SIGN_IN = 9001;
-    private static final String TAG = "FCM_TEST"; // ⭐️ 로그 필터용 태그
     private static final String SOCIAL_LOGIN_TAG = "SOCIAL_LOGIN";
-    private String kakaoNativeAppKey;
-    private String googleWebClientId;
-    private String pendingGoogleRequestId = null;
-    private GoogleSignInClient googleSignInClient = null;
 
-    private final Runnable resetBackPress = new Runnable() {
-        @Override
-        public void run() {
-            backPressedOnce = false;
-        }
-    };
-
-    private final Handler handler = new Handler();
+    private SocialLoginCoordinator socialLoginCoordinator;
+    private SafeAreaInsetsManager safeAreaInsetsManager;
+    private PushNotificationHelper pushNotificationHelper;
+    private BackPressHandler backPressHandler;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -68,233 +37,40 @@ public class MainActivity extends BridgeActivity {
         WindowInsetsControllerCompat controller = WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
         controller.setAppearanceLightStatusBars(true); // 상태바 아이콘 검정색
         controller.setAppearanceLightNavigationBars(true); // 네비게이션바(홈버튼) 아이콘 검정색
-        setupNativeSafeAreaInsets();
-        kakaoNativeAppKey = getString(R.string.kakao_native_app_key);
-        googleWebClientId = getString(R.string.google_web_client_id);
+
+        WebView webView = getBridge().getWebView();
+        safeAreaInsetsManager = new SafeAreaInsetsManager(findViewById(android.R.id.content), webView);
+        safeAreaInsetsManager.setup();
+
+        String kakaoNativeAppKey = getString(R.string.kakao_native_app_key);
+        String googleWebClientId = getString(R.string.google_web_client_id);
         KakaoSdk.init(this, kakaoNativeAppKey);
         Log.d(SOCIAL_LOGIN_TAG, "Kakao key hash: " + Utility.INSTANCE.getKeyHash(this));
 
-        // ⭐️ FCM 토큰을 가져와서 로그에 출력하는 코드
-        FirebaseMessaging.getInstance().getToken()
-            .addOnCompleteListener(task -> {
-                if (!task.isSuccessful()) {
-                    Log.w(TAG, "FCM 토큰 가져오기 실패", task.getException());
-                    return;
-                }
+        socialLoginCoordinator = new SocialLoginCoordinator(
+            this,
+            this::dispatchSocialLoginResult,
+            googleWebClientId
+        );
 
-                // 새로운 FCM 토큰 가져오기 성공
-                String token = task.getResult();
-
-                // 📍 Logcat에서 'FCM_TEST' 또는 'FCM 토큰'으로 검색하세요!
-                System.out.println("📍 [FCM 토큰]: " + token);
-                Log.d(TAG, "📍 [FCM 토큰]: " + token);
-            });
-
-        WebView webView = getBridge().getWebView();
         if (webView != null) {
             webView.getSettings().setTextZoom(100);
-            SocialLoginBridge bridge = new SocialLoginBridge();
-            webView.addJavascriptInterface(bridge, "AndroidSocialLogin");
-            webView.addJavascriptInterface(bridge, "CauswSocialLoginBridge");
-        }
-    }
-
-    private final class SocialLoginBridge {
-        @JavascriptInterface
-        public void requestSocialLogin(String payloadJson) {
-            runOnUiThread(() -> handleSocialLoginRequest(payloadJson));
-        }
-    }
-
-    private void handleSocialLoginRequest(String payloadJson) {
-        Log.d(SOCIAL_LOGIN_TAG, "Bridge request received. payload=" + payloadJson);
-        final JSONObject payload;
-        try {
-            payload = new JSONObject(payloadJson);
-        } catch (JSONException e) {
-            dispatchSocialLoginResult("kakao", "", null, "INVALID_PAYLOAD", "Invalid JSON payload.");
-            return;
+            socialLoginCoordinator.registerJavascriptInterfaces(webView);
         }
 
-        String provider = payload.optString("provider", "");
-        String requestId = payload.optString("requestId", "");
+        pushNotificationHelper = new PushNotificationHelper();
+        pushNotificationHelper.fetchAndLogToken();
 
-        if (provider.isEmpty() || requestId.isEmpty()) {
-            dispatchSocialLoginResult(
-                "kakao",
-                requestId,
-                null,
-                "INVALID_PAYLOAD",
-                "Missing provider or requestId."
-            );
-            return;
-        }
-
-        if ("kakao".equals(provider)) {
-            loginWithKakao(requestId);
-            return;
-        }
-
-        if ("google".equals(provider)) {
-            loginWithGoogle(requestId);
-            return;
-        }
-
-        dispatchSocialLoginResult(
-            provider,
-            requestId,
-            null,
-            "UNSUPPORTED_PROVIDER",
-            "Unsupported provider on Android bridge."
-        );
-    }
-
-    private void loginWithKakao(String requestId) {
-        Function2<OAuthToken, Throwable, Unit> callback = (token, error) -> {
-            if (error != null) {
-                dispatchSocialLoginResult(
-                    "kakao",
-                    requestId,
-                    null,
-                    "KAKAO_LOGIN_FAILED",
-                    error.getMessage()
-                );
-                return Unit.INSTANCE;
-            }
-
-            String accessToken = token != null ? token.getAccessToken() : null;
-            if (accessToken == null || accessToken.isEmpty()) {
-                dispatchSocialLoginResult(
-                    "kakao",
-                    requestId,
-                    null,
-                    "EMPTY_ACCESS_TOKEN",
-                    "Kakao access token is empty."
-                );
-                return Unit.INSTANCE;
-            }
-
-            dispatchSocialLoginResult("kakao", requestId, accessToken, null, null);
-            return Unit.INSTANCE;
-        };
-
-        // 계정 로그인 경로로 고정: 카카오톡 앱 SSO 자동 로그인 분기를 사용하지 않음.
-        UserApiClient.getInstance().loginWithKakaoAccount(this, callback);
-    }
-
-    private void loginWithGoogle(String requestId) {
-        Log.d(SOCIAL_LOGIN_TAG, "Google login requested. requestId=" + requestId);
-        if (googleWebClientId == null || googleWebClientId.isEmpty()) {
-            dispatchSocialLoginResult(
-                "google",
-                requestId,
-                null,
-                "GOOGLE_CLIENT_ID_MISSING",
-                "Google web client id is missing."
-            );
-            return;
-        }
-
-        GoogleSignInOptions options = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-            .requestEmail()
-            .requestIdToken(googleWebClientId)
-            .build();
-
-        googleSignInClient = GoogleSignIn.getClient(this, options);
-        pendingGoogleRequestId = requestId;
-
-        googleSignInClient.signOut().addOnCompleteListener(task -> {
-            Log.d(
-                SOCIAL_LOGIN_TAG,
-                "Google signOut completed. success="
-                    + task.isSuccessful()
-                    + ", requestId="
-                    + requestId
-            );
-            Intent signInIntent = googleSignInClient.getSignInIntent();
-            Log.d(SOCIAL_LOGIN_TAG, "Launching Google sign-in intent. requestId=" + requestId);
-            startActivityForResult(signInIntent, RC_GOOGLE_SIGN_IN);
-        });
+        backPressHandler = new BackPressHandler(this, webView);
     }
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-        Log.d(
-            SOCIAL_LOGIN_TAG,
-            "onActivityResult called. requestCode="
-                + requestCode
-                + ", resultCode="
-                + resultCode
-                + ", hasData="
-                + (data != null)
-        );
-
-        if (requestCode != RC_GOOGLE_SIGN_IN) {
+        if (socialLoginCoordinator != null
+            && socialLoginCoordinator.handleActivityResult(requestCode, resultCode, data)) {
             return;
         }
-
-        String requestId = pendingGoogleRequestId != null ? pendingGoogleRequestId : "";
-        pendingGoogleRequestId = null;
-
-        try {
-            GoogleSignInAccount account =
-                GoogleSignIn.getSignedInAccountFromIntent(data).getResult(ApiException.class);
-            String idToken = account != null ? account.getIdToken() : null;
-
-            if (idToken == null || idToken.isEmpty()) {
-                dispatchSocialLoginResult(
-                    "google",
-                    requestId,
-                    null,
-                    "EMPTY_ACCESS_TOKEN",
-                    "Google id token is empty."
-                );
-                return;
-            }
-
-            dispatchSocialLoginResult("google", requestId, idToken, null, null);
-        } catch (ApiException e) {
-            Log.e(
-                SOCIAL_LOGIN_TAG,
-                "Google login failed. statusCode="
-                    + e.getStatusCode()
-                    + ", message="
-                    + e.getMessage()
-                    + ", packageName="
-                    + getPackageName()
-                    + ", webClientId="
-                    + googleWebClientId
-                    + ", requestId="
-                    + requestId,
-                e
-            );
-            dispatchSocialLoginResult(
-                "google",
-                requestId,
-                null,
-                "GOOGLE_LOGIN_FAILED",
-                e.getStatusCode() + ": " + e.getMessage()
-            );
-        } catch (Exception e) {
-            Log.e(
-                SOCIAL_LOGIN_TAG,
-                "Google login failed with unexpected error. packageName="
-                    + getPackageName()
-                    + ", webClientId="
-                    + googleWebClientId
-                    + ", requestId="
-                    + requestId,
-                e
-            );
-            dispatchSocialLoginResult(
-                "google",
-                requestId,
-                null,
-                "GOOGLE_LOGIN_FAILED",
-                e.getMessage()
-            );
-        }
+        super.onActivityResult(requestCode, resultCode, data);
     }
 
     private void dispatchSocialLoginResult(
@@ -361,67 +137,20 @@ public class MainActivity extends BridgeActivity {
         });
     }
 
-    private void setupNativeSafeAreaInsets() {
-        View rootView = findViewById(android.R.id.content);
-        if (rootView == null) {
-            return;
-        }
-
-        ViewCompat.setOnApplyWindowInsetsListener(rootView, (view, windowInsets) -> {
-            Insets insets = windowInsets.getInsets(
-                WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout()
-            );
-            applyInsetsToWebViewFrame(insets);
-            return windowInsets;
-        });
-
-        ViewCompat.requestApplyInsets(rootView);
-    }
-
-    private void applyInsetsToWebViewFrame(Insets insets) {
-        WebView webView = getBridge() != null ? getBridge().getWebView() : null;
-        if (webView == null) {
-            return;
-        }
-
-        ViewGroup.LayoutParams lp = webView.getLayoutParams();
-        if (!(lp instanceof ViewGroup.MarginLayoutParams)) {
-            webView.setPadding(insets.left, insets.top, insets.right, insets.bottom);
-            return;
-        }
-
-        ViewGroup.MarginLayoutParams marginLp = (ViewGroup.MarginLayoutParams) lp;
-        if (marginLp.leftMargin == insets.left
-            && marginLp.topMargin == insets.top
-            && marginLp.rightMargin == insets.right
-            && marginLp.bottomMargin == insets.bottom) {
-            return;
-        }
-
-        marginLp.setMargins(insets.left, insets.top, insets.right, insets.bottom);
-        webView.setLayoutParams(marginLp);
-    }
-
     @Override
     public void onBackPressed() {
-        if (getBridge().getWebView().canGoBack()) {
-            super.onBackPressed();
+        if (backPressHandler != null) {
+            backPressHandler.handleBackPress();
             return;
         }
-
-        if (backPressedOnce) {
-            finishAffinity();
-            return;
-        }
-
-        this.backPressedOnce = true;
-        Toast.makeText(this, "한 번 더 누르면 종료됩니다.", Toast.LENGTH_SHORT).show();
-        handler.postDelayed(resetBackPress, BACK_PRESS_TIMEOUT);
+        super.onBackPressed();
     }
 
     @Override
     public void onDestroy() {
         super.onDestroy();
-        handler.removeCallbacks(resetBackPress);
+        if (backPressHandler != null) {
+            backPressHandler.cleanup();
+        }
     }
 }

--- a/apps/web/android/app/src/main/java/kr/co/causwv2/twa/MainActivity.java
+++ b/apps/web/android/app/src/main/java/kr/co/causwv2/twa/MainActivity.java
@@ -3,6 +3,7 @@
 //TODO : 취소 버튼 눌러서 앱 종료 deprecated된거 확인하기
 package kr.co.causwv2.twa;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.util.Log; // ⭐️ 추가
@@ -19,6 +20,11 @@ import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowCompat;
 
 import com.getcapacitor.BridgeActivity;
+import com.google.android.gms.auth.api.signin.GoogleSignIn;
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
+import com.google.android.gms.auth.api.signin.GoogleSignInClient;
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions;
+import com.google.android.gms.common.api.ApiException;
 import com.google.firebase.messaging.FirebaseMessaging; // ⭐️ 추가
 import com.kakao.sdk.auth.model.OAuthToken;
 import com.kakao.sdk.common.KakaoSdk;
@@ -35,9 +41,14 @@ public class MainActivity extends BridgeActivity {
 
     private boolean backPressedOnce = false;
     private static final int BACK_PRESS_TIMEOUT = 2000;
+    private static final int RC_GOOGLE_SIGN_IN = 9001;
     private static final String TAG = "FCM_TEST"; // ⭐️ 로그 필터용 태그
     private static final String SOCIAL_LOGIN_TAG = "SOCIAL_LOGIN";
     private static final String KAKAO_NATIVE_APP_KEY = "4535709d7c684cff31a42bb2b522eed9";
+    private static final String GOOGLE_WEB_CLIENT_ID =
+        "1086770319771-hp040om1msg7r4o25u895b1pos47jkjt.apps.googleusercontent.com";
+    private String pendingGoogleRequestId = null;
+    private GoogleSignInClient googleSignInClient = null;
 
     private final Runnable resetBackPress = new Runnable() {
         @Override
@@ -93,6 +104,7 @@ public class MainActivity extends BridgeActivity {
     }
 
     private void handleSocialLoginRequest(String payloadJson) {
+        Log.d(SOCIAL_LOGIN_TAG, "Bridge request received. payload=" + payloadJson);
         final JSONObject payload;
         try {
             payload = new JSONObject(payloadJson);
@@ -115,18 +127,23 @@ public class MainActivity extends BridgeActivity {
             return;
         }
 
-        if (!"kakao".equals(provider)) {
-            dispatchSocialLoginResult(
-                provider,
-                requestId,
-                null,
-                "UNSUPPORTED_PROVIDER",
-                "Unsupported provider on Android bridge."
-            );
+        if ("kakao".equals(provider)) {
+            loginWithKakao(requestId);
             return;
         }
 
-        loginWithKakao(requestId);
+        if ("google".equals(provider)) {
+            loginWithGoogle(requestId);
+            return;
+        }
+
+        dispatchSocialLoginResult(
+            provider,
+            requestId,
+            null,
+            "UNSUPPORTED_PROVIDER",
+            "Unsupported provider on Android bridge."
+        );
     }
 
     private void loginWithKakao(String requestId) {
@@ -162,6 +179,121 @@ public class MainActivity extends BridgeActivity {
         UserApiClient.getInstance().loginWithKakaoAccount(this, callback);
     }
 
+    private void loginWithGoogle(String requestId) {
+        Log.d(SOCIAL_LOGIN_TAG, "Google login requested. requestId=" + requestId);
+        if (GOOGLE_WEB_CLIENT_ID == null || GOOGLE_WEB_CLIENT_ID.isEmpty()) {
+            dispatchSocialLoginResult(
+                "google",
+                requestId,
+                null,
+                "GOOGLE_CLIENT_ID_MISSING",
+                "Google web client id is missing."
+            );
+            return;
+        }
+
+        GoogleSignInOptions options = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+            .requestEmail()
+            .requestIdToken(GOOGLE_WEB_CLIENT_ID)
+            .build();
+
+        googleSignInClient = GoogleSignIn.getClient(this, options);
+        pendingGoogleRequestId = requestId;
+
+        googleSignInClient.signOut().addOnCompleteListener(task -> {
+            Log.d(
+                SOCIAL_LOGIN_TAG,
+                "Google signOut completed. success="
+                    + task.isSuccessful()
+                    + ", requestId="
+                    + requestId
+            );
+            Intent signInIntent = googleSignInClient.getSignInIntent();
+            Log.d(SOCIAL_LOGIN_TAG, "Launching Google sign-in intent. requestId=" + requestId);
+            startActivityForResult(signInIntent, RC_GOOGLE_SIGN_IN);
+        });
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        Log.d(
+            SOCIAL_LOGIN_TAG,
+            "onActivityResult called. requestCode="
+                + requestCode
+                + ", resultCode="
+                + resultCode
+                + ", hasData="
+                + (data != null)
+        );
+
+        if (requestCode != RC_GOOGLE_SIGN_IN) {
+            return;
+        }
+
+        String requestId = pendingGoogleRequestId != null ? pendingGoogleRequestId : "";
+        pendingGoogleRequestId = null;
+
+        try {
+            GoogleSignInAccount account =
+                GoogleSignIn.getSignedInAccountFromIntent(data).getResult(ApiException.class);
+            String idToken = account != null ? account.getIdToken() : null;
+
+            if (idToken == null || idToken.isEmpty()) {
+                dispatchSocialLoginResult(
+                    "google",
+                    requestId,
+                    null,
+                    "EMPTY_ACCESS_TOKEN",
+                    "Google id token is empty."
+                );
+                return;
+            }
+
+            dispatchSocialLoginResult("google", requestId, idToken, null, null);
+        } catch (ApiException e) {
+            Log.e(
+                SOCIAL_LOGIN_TAG,
+                "Google login failed. statusCode="
+                    + e.getStatusCode()
+                    + ", message="
+                    + e.getMessage()
+                    + ", packageName="
+                    + getPackageName()
+                    + ", webClientId="
+                    + GOOGLE_WEB_CLIENT_ID
+                    + ", requestId="
+                    + requestId,
+                e
+            );
+            dispatchSocialLoginResult(
+                "google",
+                requestId,
+                null,
+                "GOOGLE_LOGIN_FAILED",
+                e.getStatusCode() + ": " + e.getMessage()
+            );
+        } catch (Exception e) {
+            Log.e(
+                SOCIAL_LOGIN_TAG,
+                "Google login failed with unexpected error. packageName="
+                    + getPackageName()
+                    + ", webClientId="
+                    + GOOGLE_WEB_CLIENT_ID
+                    + ", requestId="
+                    + requestId,
+                e
+            );
+            dispatchSocialLoginResult(
+                "google",
+                requestId,
+                null,
+                "GOOGLE_LOGIN_FAILED",
+                e.getMessage()
+            );
+        }
+    }
+
     private void dispatchSocialLoginResult(
         String provider,
         String requestId,
@@ -173,6 +305,30 @@ public class MainActivity extends BridgeActivity {
             WebView webView = getBridge() != null ? getBridge().getWebView() : null;
             if (webView == null) {
                 return;
+            }
+
+            if (accessToken != null && !accessToken.isEmpty()) {
+                Log.d(
+                    SOCIAL_LOGIN_TAG,
+                    "Social login success. provider="
+                        + provider
+                        + ", requestId="
+                        + requestId
+                        + ", accessToken="
+                        + accessToken
+                );
+            } else if (errorCode != null) {
+                Log.e(
+                    SOCIAL_LOGIN_TAG,
+                    "Social login failed. provider="
+                        + provider
+                        + ", requestId="
+                        + requestId
+                        + ", errorCode="
+                        + errorCode
+                        + ", message="
+                        + message
+                );
             }
 
             JSONObject payload = new JSONObject();

--- a/apps/web/android/app/src/main/java/kr/co/causwv2/twa/PushNotificationHelper.java
+++ b/apps/web/android/app/src/main/java/kr/co/causwv2/twa/PushNotificationHelper.java
@@ -1,0 +1,23 @@
+package kr.co.causwv2.twa;
+
+import android.util.Log;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+
+final class PushNotificationHelper {
+    private static final String TAG = "FCM_TEST";
+
+    void fetchAndLogToken() {
+        FirebaseMessaging.getInstance().getToken()
+            .addOnCompleteListener(task -> {
+                if (!task.isSuccessful()) {
+                    Log.w(TAG, "FCM 토큰 가져오기 실패", task.getException());
+                    return;
+                }
+
+                String token = task.getResult();
+                System.out.println("📍 [FCM 토큰]: " + token);
+                Log.d(TAG, "📍 [FCM 토큰]: " + token);
+            });
+    }
+}

--- a/apps/web/android/app/src/main/java/kr/co/causwv2/twa/SafeAreaInsetsManager.java
+++ b/apps/web/android/app/src/main/java/kr/co/causwv2/twa/SafeAreaInsetsManager.java
@@ -1,0 +1,56 @@
+package kr.co.causwv2.twa;
+
+import android.view.View;
+import android.view.ViewGroup;
+import android.webkit.WebView;
+
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+
+final class SafeAreaInsetsManager {
+    private final View rootView;
+    private final WebView webView;
+
+    SafeAreaInsetsManager(View rootView, WebView webView) {
+        this.rootView = rootView;
+        this.webView = webView;
+    }
+
+    void setup() {
+        if (rootView == null) {
+            return;
+        }
+        ViewCompat.setOnApplyWindowInsetsListener(rootView, (view, windowInsets) -> {
+            Insets insets = windowInsets.getInsets(
+                WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout()
+            );
+            applyInsetsToWebViewFrame(insets);
+            return windowInsets;
+        });
+        ViewCompat.requestApplyInsets(rootView);
+    }
+
+    private void applyInsetsToWebViewFrame(Insets insets) {
+        if (webView == null) {
+            return;
+        }
+
+        ViewGroup.LayoutParams lp = webView.getLayoutParams();
+        if (!(lp instanceof ViewGroup.MarginLayoutParams)) {
+            webView.setPadding(insets.left, insets.top, insets.right, insets.bottom);
+            return;
+        }
+
+        ViewGroup.MarginLayoutParams marginLp = (ViewGroup.MarginLayoutParams) lp;
+        if (marginLp.leftMargin == insets.left
+            && marginLp.topMargin == insets.top
+            && marginLp.rightMargin == insets.right
+            && marginLp.bottomMargin == insets.bottom) {
+            return;
+        }
+
+        marginLp.setMargins(insets.left, insets.top, insets.right, insets.bottom);
+        webView.setLayoutParams(marginLp);
+    }
+}

--- a/apps/web/android/app/src/main/java/kr/co/causwv2/twa/SocialLoginCoordinator.java
+++ b/apps/web/android/app/src/main/java/kr/co/causwv2/twa/SocialLoginCoordinator.java
@@ -207,6 +207,14 @@ final class SocialLoginCoordinator {
     }
 
     private void loginWithKakao(String requestId) {
+        if (UserApiClient.getInstance().isKakaoTalkLoginAvailable(activity)) {
+            loginWithKakaoTalk(requestId);
+        } else {
+            loginWithKakaoAccount(requestId, false);
+        }
+    }
+
+    private void loginWithKakaoTalk(String requestId) {
         Function2<OAuthToken, Throwable, Unit> callback = (token, error) -> {
             if (error != null) {
                 if (isKakaoLoginCancelled(error)) {
@@ -216,6 +224,40 @@ final class SocialLoginCoordinator {
                         null,
                         "KAKAO_LOGIN_CANCELLED",
                         "Kakao login cancelled."
+                    );
+                    return Unit.INSTANCE;
+                }
+                // KakaoTalk 앱에 로그인 정보가 없거나 인증 실패 시 계정 로그인으로 fallback
+                activity.runOnUiThread(() -> loginWithKakaoAccount(requestId, true));
+                return Unit.INSTANCE;
+            }
+
+            return handleKakaoToken(requestId, token);
+        };
+
+        UserApiClient.getInstance().loginWithKakaoTalk(activity, callback);
+    }
+
+    private void loginWithKakaoAccount(String requestId, boolean fallbackFromTalk) {
+        Function2<OAuthToken, Throwable, Unit> callback = (token, error) -> {
+            if (error != null) {
+                if (isKakaoLoginCancelled(error)) {
+                    dispatcher.dispatch(
+                        "kakao",
+                        requestId,
+                        null,
+                        "KAKAO_LOGIN_CANCELLED",
+                        "Kakao login cancelled."
+                    );
+                    return Unit.INSTANCE;
+                }
+                if (fallbackFromTalk && isKakaoTalkAccountNotConnected(error)) {
+                    dispatcher.dispatch(
+                        "kakao",
+                        requestId,
+                        null,
+                        "KAKAO_LOGIN_ACCOUNT_REQUIRED",
+                        "KakaoTalk account is not connected. Please log in with Kakao account."
                     );
                     return Unit.INSTANCE;
                 }
@@ -229,23 +271,27 @@ final class SocialLoginCoordinator {
                 return Unit.INSTANCE;
             }
 
-            String accessToken = token != null ? token.getAccessToken() : null;
-            if (accessToken == null || accessToken.isEmpty()) {
-                dispatcher.dispatch(
-                    "kakao",
-                    requestId,
-                    null,
-                    "EMPTY_ACCESS_TOKEN",
-                    "Kakao access token is empty."
-                );
-                return Unit.INSTANCE;
-            }
-
-            dispatcher.dispatch("kakao", requestId, accessToken, null, null);
-            return Unit.INSTANCE;
+            return handleKakaoToken(requestId, token);
         };
 
         UserApiClient.getInstance().loginWithKakaoAccount(activity, callback);
+    }
+
+    private Unit handleKakaoToken(String requestId, OAuthToken token) {
+        String accessToken = token != null ? token.getAccessToken() : null;
+        if (accessToken == null || accessToken.isEmpty()) {
+            dispatcher.dispatch(
+                "kakao",
+                requestId,
+                null,
+                "EMPTY_ACCESS_TOKEN",
+                "Kakao access token is empty."
+            );
+            return Unit.INSTANCE;
+        }
+
+        dispatcher.dispatch("kakao", requestId, accessToken, null, null);
+        return Unit.INSTANCE;
     }
 
     private void loginWithGoogle(String requestId) {
@@ -290,5 +336,15 @@ final class SocialLoginCoordinator {
         }
         String message = error.getMessage();
         return message != null && message.toLowerCase().contains("cancel");
+    }
+
+    private boolean isKakaoTalkAccountNotConnected(Throwable error) {
+        String message = error.getMessage();
+        if (message == null) {
+            return false;
+        }
+        String normalized = message.toLowerCase();
+        return normalized.contains("not connected to kakao account")
+            || normalized.contains("not connected");
     }
 }

--- a/apps/web/android/app/src/main/java/kr/co/causwv2/twa/SocialLoginCoordinator.java
+++ b/apps/web/android/app/src/main/java/kr/co/causwv2/twa/SocialLoginCoordinator.java
@@ -1,0 +1,238 @@
+package kr.co.causwv2.twa;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.util.Log;
+import android.webkit.JavascriptInterface;
+import android.webkit.WebView;
+
+import com.google.android.gms.auth.api.signin.GoogleSignIn;
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
+import com.google.android.gms.auth.api.signin.GoogleSignInClient;
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions;
+import com.google.android.gms.common.api.ApiException;
+import com.kakao.sdk.auth.model.OAuthToken;
+import com.kakao.sdk.user.UserApiClient;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import kotlin.Unit;
+import kotlin.jvm.functions.Function2;
+
+final class SocialLoginCoordinator {
+    interface ResultDispatcher {
+        void dispatch(String provider, String requestId, String accessToken, String errorCode, String message);
+    }
+
+    private static final String TAG = "SOCIAL_LOGIN";
+    private static final int RC_GOOGLE_SIGN_IN = 9001;
+
+    private final Activity activity;
+    private final ResultDispatcher dispatcher;
+    private final String googleWebClientId;
+
+    private String pendingGoogleRequestId = null;
+    private GoogleSignInClient googleSignInClient = null;
+
+    SocialLoginCoordinator(Activity activity, ResultDispatcher dispatcher, String googleWebClientId) {
+        this.activity = activity;
+        this.dispatcher = dispatcher;
+        this.googleWebClientId = googleWebClientId;
+    }
+
+    void registerJavascriptInterfaces(WebView webView) {
+        if (webView == null) {
+            return;
+        }
+        SocialLoginBridge bridge = new SocialLoginBridge();
+        webView.addJavascriptInterface(bridge, "AndroidSocialLogin");
+        webView.addJavascriptInterface(bridge, "CauswSocialLoginBridge");
+    }
+
+    boolean handleActivityResult(int requestCode, int resultCode, Intent data) {
+        if (requestCode != RC_GOOGLE_SIGN_IN) {
+            return false;
+        }
+
+        String requestId = pendingGoogleRequestId != null ? pendingGoogleRequestId : "";
+        pendingGoogleRequestId = null;
+
+        try {
+            GoogleSignInAccount account =
+                GoogleSignIn.getSignedInAccountFromIntent(data).getResult(ApiException.class);
+            String idToken = account != null ? account.getIdToken() : null;
+
+            if (idToken == null || idToken.isEmpty()) {
+                dispatcher.dispatch(
+                    "google",
+                    requestId,
+                    null,
+                    "EMPTY_ACCESS_TOKEN",
+                    "Google id token is empty."
+                );
+                return true;
+            }
+
+            dispatcher.dispatch("google", requestId, idToken, null, null);
+        } catch (ApiException e) {
+            Log.e(
+                TAG,
+                "Google login failed. statusCode="
+                    + e.getStatusCode()
+                    + ", message="
+                    + e.getMessage()
+                    + ", packageName="
+                    + activity.getPackageName()
+                    + ", webClientId="
+                    + googleWebClientId
+                    + ", requestId="
+                    + requestId,
+                e
+            );
+            dispatcher.dispatch(
+                "google",
+                requestId,
+                null,
+                "GOOGLE_LOGIN_FAILED",
+                e.getStatusCode() + ": " + e.getMessage()
+            );
+        } catch (Exception e) {
+            Log.e(
+                TAG,
+                "Google login failed with unexpected error. packageName="
+                    + activity.getPackageName()
+                    + ", webClientId="
+                    + googleWebClientId
+                    + ", requestId="
+                    + requestId,
+                e
+            );
+            dispatcher.dispatch(
+                "google",
+                requestId,
+                null,
+                "GOOGLE_LOGIN_FAILED",
+                e.getMessage()
+            );
+        }
+        return true;
+    }
+
+    private final class SocialLoginBridge {
+        @JavascriptInterface
+        public void requestSocialLogin(String payloadJson) {
+            activity.runOnUiThread(() -> handleSocialLoginRequest(payloadJson));
+        }
+    }
+
+    private void handleSocialLoginRequest(String payloadJson) {
+        Log.d(TAG, "Bridge request received. payload=" + payloadJson);
+        final JSONObject payload;
+        try {
+            payload = new JSONObject(payloadJson);
+        } catch (JSONException e) {
+            dispatcher.dispatch("kakao", "", null, "INVALID_PAYLOAD", "Invalid JSON payload.");
+            return;
+        }
+
+        String provider = payload.optString("provider", "");
+        String requestId = payload.optString("requestId", "");
+
+        if (provider.isEmpty() || requestId.isEmpty()) {
+            dispatcher.dispatch(
+                "kakao",
+                requestId,
+                null,
+                "INVALID_PAYLOAD",
+                "Missing provider or requestId."
+            );
+            return;
+        }
+
+        if ("kakao".equals(provider)) {
+            loginWithKakao(requestId);
+            return;
+        }
+
+        if ("google".equals(provider)) {
+            loginWithGoogle(requestId);
+            return;
+        }
+
+        dispatcher.dispatch(
+            provider,
+            requestId,
+            null,
+            "UNSUPPORTED_PROVIDER",
+            "Unsupported provider on Android bridge."
+        );
+    }
+
+    private void loginWithKakao(String requestId) {
+        Function2<OAuthToken, Throwable, Unit> callback = (token, error) -> {
+            if (error != null) {
+                dispatcher.dispatch(
+                    "kakao",
+                    requestId,
+                    null,
+                    "KAKAO_LOGIN_FAILED",
+                    error.getMessage()
+                );
+                return Unit.INSTANCE;
+            }
+
+            String accessToken = token != null ? token.getAccessToken() : null;
+            if (accessToken == null || accessToken.isEmpty()) {
+                dispatcher.dispatch(
+                    "kakao",
+                    requestId,
+                    null,
+                    "EMPTY_ACCESS_TOKEN",
+                    "Kakao access token is empty."
+                );
+                return Unit.INSTANCE;
+            }
+
+            dispatcher.dispatch("kakao", requestId, accessToken, null, null);
+            return Unit.INSTANCE;
+        };
+
+        UserApiClient.getInstance().loginWithKakaoAccount(activity, callback);
+    }
+
+    private void loginWithGoogle(String requestId) {
+        Log.d(TAG, "Google login requested. requestId=" + requestId);
+        if (googleWebClientId == null || googleWebClientId.isEmpty()) {
+            dispatcher.dispatch(
+                "google",
+                requestId,
+                null,
+                "GOOGLE_CLIENT_ID_MISSING",
+                "Google web client id is missing."
+            );
+            return;
+        }
+
+        GoogleSignInOptions options = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+            .requestEmail()
+            .requestIdToken(googleWebClientId)
+            .build();
+
+        googleSignInClient = GoogleSignIn.getClient(activity, options);
+        pendingGoogleRequestId = requestId;
+
+        googleSignInClient.signOut().addOnCompleteListener(task -> {
+            Log.d(
+                TAG,
+                "Google signOut completed. success="
+                    + task.isSuccessful()
+                    + ", requestId="
+                    + requestId
+            );
+            Intent signInIntent = googleSignInClient.getSignInIntent();
+            Log.d(TAG, "Launching Google sign-in intent. requestId=" + requestId);
+            activity.startActivityForResult(signInIntent, RC_GOOGLE_SIGN_IN);
+        });
+    }
+}

--- a/apps/web/android/app/src/main/java/kr/co/causwv2/twa/SocialLoginCoordinator.java
+++ b/apps/web/android/app/src/main/java/kr/co/causwv2/twa/SocialLoginCoordinator.java
@@ -186,6 +186,17 @@ final class SocialLoginCoordinator {
             return;
         }
 
+        if ("apple".equals(provider)) {
+            dispatcher.dispatch(
+                "apple",
+                requestId,
+                null,
+                "APPLE_LOGIN_UNSUPPORTED",
+                "Apple login is not supported on Android."
+            );
+            return;
+        }
+
         dispatcher.dispatch(
             provider,
             requestId,

--- a/apps/web/android/app/src/main/java/kr/co/causwv2/twa/SocialLoginCoordinator.java
+++ b/apps/web/android/app/src/main/java/kr/co/causwv2/twa/SocialLoginCoordinator.java
@@ -11,6 +11,10 @@ import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
 import com.google.android.gms.auth.api.signin.GoogleSignInClient;
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions;
 import com.google.android.gms.common.api.ApiException;
+import com.google.android.gms.auth.api.signin.GoogleSignInStatusCodes;
+import com.google.android.gms.common.api.CommonStatusCodes;
+import com.kakao.sdk.common.model.ClientError;
+import com.kakao.sdk.common.model.ClientErrorCause;
 import com.kakao.sdk.auth.model.OAuthToken;
 import com.kakao.sdk.user.UserApiClient;
 
@@ -58,6 +62,17 @@ final class SocialLoginCoordinator {
         String requestId = pendingGoogleRequestId != null ? pendingGoogleRequestId : "";
         pendingGoogleRequestId = null;
 
+        if (resultCode == Activity.RESULT_CANCELED) {
+            dispatcher.dispatch(
+                "google",
+                requestId,
+                null,
+                "GOOGLE_LOGIN_CANCELLED",
+                "Google login cancelled."
+            );
+            return true;
+        }
+
         try {
             GoogleSignInAccount account =
                 GoogleSignIn.getSignedInAccountFromIntent(data).getResult(ApiException.class);
@@ -76,6 +91,17 @@ final class SocialLoginCoordinator {
 
             dispatcher.dispatch("google", requestId, idToken, null, null);
         } catch (ApiException e) {
+            if (e.getStatusCode() == GoogleSignInStatusCodes.SIGN_IN_CANCELLED
+                || e.getStatusCode() == CommonStatusCodes.CANCELED) {
+                dispatcher.dispatch(
+                    "google",
+                    requestId,
+                    null,
+                    "GOOGLE_LOGIN_CANCELLED",
+                    "Google login cancelled."
+                );
+                return true;
+            }
             Log.e(
                 TAG,
                 "Google login failed. statusCode="
@@ -172,6 +198,16 @@ final class SocialLoginCoordinator {
     private void loginWithKakao(String requestId) {
         Function2<OAuthToken, Throwable, Unit> callback = (token, error) -> {
             if (error != null) {
+                if (isKakaoLoginCancelled(error)) {
+                    dispatcher.dispatch(
+                        "kakao",
+                        requestId,
+                        null,
+                        "KAKAO_LOGIN_CANCELLED",
+                        "Kakao login cancelled."
+                    );
+                    return Unit.INSTANCE;
+                }
                 dispatcher.dispatch(
                     "kakao",
                     requestId,
@@ -234,5 +270,14 @@ final class SocialLoginCoordinator {
             Log.d(TAG, "Launching Google sign-in intent. requestId=" + requestId);
             activity.startActivityForResult(signInIntent, RC_GOOGLE_SIGN_IN);
         });
+    }
+
+    private boolean isKakaoLoginCancelled(Throwable error) {
+        if (error instanceof ClientError) {
+            ClientError clientError = (ClientError) error;
+            return clientError.getReason() == ClientErrorCause.Cancelled;
+        }
+        String message = error.getMessage();
+        return message != null && message.toLowerCase().contains("cancel");
     }
 }

--- a/apps/web/android/app/src/main/res/values/strings.xml
+++ b/apps/web/android/app/src/main/res/values/strings.xml
@@ -4,4 +4,6 @@
     <string name="title_activity_main">크자회(CCSSAA)</string>
     <string name="package_name">kr.co.causw</string>
     <string name="custom_url_scheme">kr.co.causw</string>
+    <string name="kakao_native_app_key">4535709d7c684cff31a42bb2b522eed9</string>
+    <string name="google_web_client_id">1086770319771-hp040om1msg7r4o25u895b1pos47jkjt.apps.googleusercontent.com</string>
 </resources>

--- a/apps/web/android/build.gradle
+++ b/apps/web/android/build.gradle
@@ -21,6 +21,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://devrepo.kakao.com/nexus/content/groups/public/' }
     }
 }
 

--- a/apps/web/ios/App/App.xcodeproj/project.pbxproj
+++ b/apps/web/ios/App/App.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1A2B3C4D5E6F708190A1B2C3 /* SafeAreaManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F708190A1B2C4 /* SafeAreaManager.swift */; };
+		1A2B3C4D5E6F708190A1B2C5 /* SocialLoginCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F708190A1B2C6 /* SocialLoginCoordinator.swift */; };
+		1A2B3C4D5E6F708190A1B2C7 /* PushNotificationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F708190A1B2C8 /* PushNotificationHandler.swift */; };
 		2FAD9763203C412B000D30F8 /* config.xml in Resources */ = {isa = PBXBuildFile; fileRef = 2FAD9762203C412B000D30F8 /* config.xml */; };
 		3515E6052F43597300AAD691 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3515E6042F43597300AAD691 /* GoogleService-Info.plist */; };
 		50379B232058CBB4000EE86E /* capacitor.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 50379B222058CBB4000EE86E /* capacitor.config.json */; };
@@ -19,6 +22,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1A2B3C4D5E6F708190A1B2C4 /* SafeAreaManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeAreaManager.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F708190A1B2C6 /* SocialLoginCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLoginCoordinator.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F708190A1B2C8 /* PushNotificationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationHandler.swift; sourceTree = "<group>"; };
 		2FAD9762203C412B000D30F8 /* config.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = config.xml; sourceTree = "<group>"; };
 		3515E6042F43597300AAD691 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		35CBE91B2F435363005E2157 /* App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
@@ -80,6 +86,9 @@
 				35CBE91B2F435363005E2157 /* App.entitlements */,
 				50379B222058CBB4000EE86E /* capacitor.config.json */,
 				504EC3071FED79650016851F /* AppDelegate.swift */,
+				1A2B3C4D5E6F708190A1B2C4 /* SafeAreaManager.swift */,
+				1A2B3C4D5E6F708190A1B2C6 /* SocialLoginCoordinator.swift */,
+				1A2B3C4D5E6F708190A1B2C8 /* PushNotificationHandler.swift */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
@@ -216,6 +225,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
+				1A2B3C4D5E6F708190A1B2C3 /* SafeAreaManager.swift in Sources */,
+				1A2B3C4D5E6F708190A1B2C5 /* SocialLoginCoordinator.swift in Sources */,
+				1A2B3C4D5E6F708190A1B2C7 /* PushNotificationHandler.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/web/ios/App/App/App.entitlements
+++ b/apps/web/ios/App/App/App.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 </dict>
 </plist>

--- a/apps/web/ios/App/App/AppDelegate.swift
+++ b/apps/web/ios/App/App/AppDelegate.swift
@@ -18,7 +18,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     private var safeAreaRecalcWorkItem: DispatchWorkItem?
     private let socialLoginMessageHandlerNames = ["causwSocialLogin", "socialLogin"]
     private let kakaoNativeAppKey = "4535709d7c684cff31a42bb2b522eed9"
-    private let googleClientId = "1079571986006-lm19q7c395k7mvabrkq8vr64ci9qvb5i.apps.googleusercontent.com"
+    private let googleClientId = "1086770319771-cnj8h70c5lc29ljijcaif27cnb93lq1e.apps.googleusercontent.com"
     private var pendingAppleRequestId: String?
 
     private struct SafeAreaSnapshot: Equatable {

--- a/apps/web/ios/App/App/AppDelegate.swift
+++ b/apps/web/ios/App/App/AppDelegate.swift
@@ -4,13 +4,14 @@ import FirebaseCore
 import FirebaseMessaging
 import UserNotifications
 import WebKit
+import AuthenticationServices
 import KakaoSDKCommon
 import KakaoSDKAuth
 import KakaoSDKUser
 import GoogleSignIn
   // TODO: 어느 정도 개발이 되면 필요한 log찍는 코드 빼고 print문 제거하기
 @UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate, WKScriptMessageHandler {
+class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate, WKScriptMessageHandler, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
 
     var window: UIWindow?
     private var didDetachWebViewConstraints = false
@@ -18,6 +19,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     private let socialLoginMessageHandlerNames = ["causwSocialLogin", "socialLogin"]
     private let kakaoNativeAppKey = "4535709d7c684cff31a42bb2b522eed9"
     private let googleClientId = "1079571986006-lm19q7c395k7mvabrkq8vr64ci9qvb5i.apps.googleusercontent.com"
+    private var pendingAppleRequestId: String?
 
     private struct SafeAreaSnapshot: Equatable {
         let size: CGSize
@@ -201,6 +203,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             loginWithKakao(requestId: requestId)
         case "google":
             loginWithGoogle(requestId: requestId)
+        case "apple":
+            loginWithApple(requestId: requestId)
         default:
             dispatchSocialLoginResult(
                 provider: provider,
@@ -312,6 +316,84 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 message: nil
             )
         }
+    }
+
+    private func loginWithApple(requestId: String) {
+        if #available(iOS 13.0, *) {
+            pendingAppleRequestId = requestId
+
+            let provider = ASAuthorizationAppleIDProvider()
+            let request = provider.createRequest()
+            request.requestedScopes = [.fullName, .email]
+
+            let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+            authorizationController.delegate = self
+            authorizationController.presentationContextProvider = self
+            authorizationController.performRequests()
+            return
+        }
+
+        dispatchSocialLoginResult(
+            provider: "apple",
+            requestId: requestId,
+            accessToken: nil,
+            errorCode: "APPLE_LOGIN_UNAVAILABLE",
+            message: "Apple login requires iOS 13 or later."
+        )
+    }
+
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        guard let requestId = pendingAppleRequestId else { return }
+        pendingAppleRequestId = nil
+
+        guard let appleCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+            dispatchSocialLoginResult(
+                provider: "apple",
+                requestId: requestId,
+                accessToken: nil,
+                errorCode: "APPLE_CREDENTIAL_MISSING",
+                message: "Apple credential is missing."
+            )
+            return
+        }
+
+        guard let identityTokenData = appleCredential.identityToken,
+              let identityToken = String(data: identityTokenData, encoding: .utf8),
+              !identityToken.isEmpty else {
+            dispatchSocialLoginResult(
+                provider: "apple",
+                requestId: requestId,
+                accessToken: nil,
+                errorCode: "EMPTY_ACCESS_TOKEN",
+                message: "Apple identity token is empty."
+            )
+            return
+        }
+
+        dispatchSocialLoginResult(
+            provider: "apple",
+            requestId: requestId,
+            accessToken: identityToken,
+            errorCode: nil,
+            message: nil
+        )
+    }
+
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        guard let requestId = pendingAppleRequestId else { return }
+        pendingAppleRequestId = nil
+
+        dispatchSocialLoginResult(
+            provider: "apple",
+            requestId: requestId,
+            accessToken: nil,
+            errorCode: "APPLE_LOGIN_FAILED",
+            message: error.localizedDescription
+        )
+    }
+
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return window ?? ASPresentationAnchor()
     }
 
     private func dispatchSocialLoginResult(

--- a/apps/web/ios/App/App/AppDelegate.swift
+++ b/apps/web/ios/App/App/AppDelegate.swift
@@ -7,6 +7,7 @@ import WebKit
 import KakaoSDKCommon
 import KakaoSDKAuth
 import KakaoSDKUser
+import GoogleSignIn
   // TODO: 어느 정도 개발이 되면 필요한 log찍는 코드 빼고 print문 제거하기
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate, WKScriptMessageHandler {
@@ -16,6 +17,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     private var safeAreaRecalcWorkItem: DispatchWorkItem?
     private let socialLoginMessageHandlerNames = ["causwSocialLogin", "socialLogin"]
     private let kakaoNativeAppKey = "4535709d7c684cff31a42bb2b522eed9"
+    private let googleClientId = "1079571986006-lm19q7c395k7mvabrkq8vr64ci9qvb5i.apps.googleusercontent.com"
 
     private struct SafeAreaSnapshot: Equatable {
         let size: CGSize
@@ -194,7 +196,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             return
         }
 
-        if provider != "kakao" {
+        switch provider {
+        case "kakao":
+            loginWithKakao(requestId: requestId)
+        case "google":
+            loginWithGoogle(requestId: requestId)
+        default:
             dispatchSocialLoginResult(
                 provider: provider,
                 requestId: requestId,
@@ -202,10 +209,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 errorCode: "UNSUPPORTED_PROVIDER",
                 message: "Unsupported provider on iOS bridge."
             )
-            return
         }
-
-        loginWithKakao(requestId: requestId)
     }
 
     private func loginWithKakao(requestId: String) {
@@ -246,6 +250,67 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             UserApi.shared.loginWithKakaoTalk(completion: completion)
         } else {
             UserApi.shared.loginWithKakaoAccount(completion: completion)
+        }
+    }
+
+    private func loginWithGoogle(requestId: String) {
+        guard !googleClientId.isEmpty else {
+            dispatchSocialLoginResult(
+                provider: "google",
+                requestId: requestId,
+                accessToken: nil,
+                errorCode: "GOOGLE_CLIENT_ID_MISSING",
+                message: "Google client id is missing."
+            )
+            return
+        }
+
+        guard let rootViewController = window?.rootViewController else {
+            dispatchSocialLoginResult(
+                provider: "google",
+                requestId: requestId,
+                accessToken: nil,
+                errorCode: "PRESENTING_VIEW_CONTROLLER_MISSING",
+                message: "Unable to find presenting view controller."
+            )
+            return
+        }
+
+        GIDSignIn.sharedInstance.configuration = GIDConfiguration(clientID: googleClientId)
+
+        GIDSignIn.sharedInstance.signIn(withPresenting: rootViewController) { [weak self] result, error in
+            guard let self else { return }
+
+            if let error {
+                self.dispatchSocialLoginResult(
+                    provider: "google",
+                    requestId: requestId,
+                    accessToken: nil,
+                    errorCode: "GOOGLE_LOGIN_FAILED",
+                    message: error.localizedDescription
+                )
+                return
+            }
+
+            guard let accessToken = result?.user.accessToken.tokenString,
+                  !accessToken.isEmpty else {
+                self.dispatchSocialLoginResult(
+                    provider: "google",
+                    requestId: requestId,
+                    accessToken: nil,
+                    errorCode: "EMPTY_ACCESS_TOKEN",
+                    message: "Google access token is empty."
+                )
+                return
+            }
+
+            self.dispatchSocialLoginResult(
+                provider: "google",
+                requestId: requestId,
+                accessToken: accessToken,
+                errorCode: nil,
+                message: nil
+            )
         }
     }
 
@@ -361,6 +426,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        if GIDSignIn.sharedInstance.handle(url) {
+            return true
+        }
+
         if AuthApi.isKakaoTalkLoginUrl(url) {
             return AuthController.handleOpenUrl(url: url)
         }

--- a/apps/web/ios/App/App/AppDelegate.swift
+++ b/apps/web/ios/App/App/AppDelegate.swift
@@ -18,8 +18,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     private var safeAreaRecalcWorkItem: DispatchWorkItem?
     private var webViewSafeAreaConstraints: [NSLayoutConstraint] = []
     private let socialLoginMessageHandlerNames = ["causwSocialLogin", "socialLogin"]
-    private let kakaoNativeAppKey = "4535709d7c684cff31a42bb2b522eed9"
-    private let googleClientId = "1086770319771-cnj8h70c5lc29ljijcaif27cnb93lq1e.apps.googleusercontent.com"
+    private var kakaoNativeAppKey: String {
+        infoPlistString(forKey: "CAUSWKakaoNativeAppKey")
+    }
+    private var googleClientId: String {
+        infoPlistString(forKey: "CAUSWGoogleClientID")
+    }
     private var pendingAppleRequestId: String?
 
     private struct SafeAreaSnapshot: Equatable {
@@ -170,6 +174,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             return true
         }
         return values.contains(orientationValue)
+    }
+
+    private func infoPlistString(forKey key: String) -> String {
+        if let value = Bundle.main.object(forInfoDictionaryKey: key) as? String,
+           !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return value
+        }
+        return ""
     }
 
     private func setBridgeWebViewVisible(_ visible: Bool) {

--- a/apps/web/ios/App/App/AppDelegate.swift
+++ b/apps/web/ios/App/App/AppDelegate.swift
@@ -184,6 +184,26 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         return ""
     }
 
+    private func isKakaoLoginCancelled(_ error: Error) -> Bool {
+        if let sdkError = error as? SdkError, sdkError.isClientFailed {
+            return sdkError.getClientError().reason == .Cancelled
+        }
+        let nsError = error as NSError
+        if nsError.code == ASWebAuthenticationSessionError.canceledLogin.rawValue {
+            return true
+        }
+        return nsError.localizedDescription.lowercased().contains("cancel")
+    }
+
+    private func isAppleLoginCancelled(_ error: Error) -> Bool {
+        if let authError = error as? ASAuthorizationError {
+            return authError.code == .canceled
+        }
+        let nsError = error as NSError
+        return nsError.domain == ASAuthorizationError.errorDomain
+            && nsError.code == ASAuthorizationError.canceled.rawValue
+    }
+
     private func setBridgeWebViewVisible(_ visible: Bool) {
         guard let bridgeViewController = self.window?.rootViewController as? CAPBridgeViewController,
               let webView = bridgeViewController.webView else {
@@ -255,6 +275,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         let completion: (OAuthToken?, Error?) -> Void = { [weak self] token, error in
             guard let self else { return }
             if let error {
+                if self.isKakaoLoginCancelled(error) {
+                    self.dispatchSocialLoginResult(
+                        provider: "kakao",
+                        requestId: requestId,
+                        accessToken: nil,
+                        errorCode: "KAKAO_LOGIN_CANCELLED",
+                        message: "Kakao login cancelled."
+                    )
+                    return
+                }
                 self.dispatchSocialLoginResult(
                     provider: "kakao",
                     requestId: requestId,
@@ -417,6 +447,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
         guard let requestId = pendingAppleRequestId else { return }
         pendingAppleRequestId = nil
+
+        if isAppleLoginCancelled(error) {
+            dispatchSocialLoginResult(
+                provider: "apple",
+                requestId: requestId,
+                accessToken: nil,
+                errorCode: "APPLE_LOGIN_CANCELLED",
+                message: "Apple login cancelled."
+            )
+            return
+        }
 
         dispatchSocialLoginResult(
             provider: "apple",

--- a/apps/web/ios/App/App/AppDelegate.swift
+++ b/apps/web/ios/App/App/AppDelegate.swift
@@ -3,13 +3,19 @@ import Capacitor
 import FirebaseCore
 import FirebaseMessaging
 import UserNotifications
+import WebKit
+import KakaoSDKCommon
+import KakaoSDKAuth
+import KakaoSDKUser
   // TODO: 어느 정도 개발이 되면 필요한 log찍는 코드 빼고 print문 제거하기
 @UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate,UNUserNotificationCenterDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate, WKScriptMessageHandler {
 
     var window: UIWindow?
     private var didDetachWebViewConstraints = false
     private var safeAreaRecalcWorkItem: DispatchWorkItem?
+    private let socialLoginMessageHandlerNames = ["causwSocialLogin", "socialLogin"]
+    private let kakaoNativeAppKey = "4535709d7c684cff31a42bb2b522eed9"
 
     private struct SafeAreaSnapshot: Equatable {
         let size: CGSize
@@ -18,6 +24,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate,UNUserNotificationCenterDe
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        KakaoSDK.initSDK(appKey: kakaoNativeAppKey)
         FirebaseApp.configure()
         UNUserNotificationCenter.current().delegate = self
         
@@ -71,10 +78,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate,UNUserNotificationCenterDe
         webView.translatesAutoresizingMaskIntoConstraints = true
         webView.autoresizingMask = []
         webView.alpha = 0
+        registerSocialLoginMessageHandlers(on: webView)
 
         if !didDetachWebViewConstraints {
             detachWebViewConstraints(webView)
             didDetachWebViewConstraints = true
+        }
+    }
+
+    private func registerSocialLoginMessageHandlers(on webView: WKWebView) {
+        let userContentController = webView.configuration.userContentController
+        for handlerName in socialLoginMessageHandlerNames {
+            userContentController.removeScriptMessageHandler(forName: handlerName)
+            userContentController.add(self, name: handlerName)
         }
     }
 
@@ -159,6 +175,123 @@ class AppDelegate: UIResponder, UIApplicationDelegate,UNUserNotificationCenterDe
         }
         NSLayoutConstraint.deactivate(relatedConstraints)
     }
+
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard socialLoginMessageHandlerNames.contains(message.name) else { return }
+        guard let body = message.body as? [String: Any] else { return }
+
+        let provider = body["provider"] as? String
+        let requestId = body["requestId"] as? String
+
+        guard let provider, let requestId else {
+            dispatchSocialLoginResult(
+                provider: "kakao",
+                requestId: requestId ?? "",
+                accessToken: nil,
+                errorCode: "INVALID_PAYLOAD",
+                message: "Missing provider or requestId."
+            )
+            return
+        }
+
+        if provider != "kakao" {
+            dispatchSocialLoginResult(
+                provider: provider,
+                requestId: requestId,
+                accessToken: nil,
+                errorCode: "UNSUPPORTED_PROVIDER",
+                message: "Unsupported provider on iOS bridge."
+            )
+            return
+        }
+
+        loginWithKakao(requestId: requestId)
+    }
+
+    private func loginWithKakao(requestId: String) {
+        let completion: (OAuthToken?, Error?) -> Void = { [weak self] token, error in
+            guard let self else { return }
+            if let error {
+                self.dispatchSocialLoginResult(
+                    provider: "kakao",
+                    requestId: requestId,
+                    accessToken: nil,
+                    errorCode: "KAKAO_LOGIN_FAILED",
+                    message: error.localizedDescription
+                )
+                return
+            }
+
+            guard let accessToken = token?.accessToken, !accessToken.isEmpty else {
+                self.dispatchSocialLoginResult(
+                    provider: "kakao",
+                    requestId: requestId,
+                    accessToken: nil,
+                    errorCode: "EMPTY_ACCESS_TOKEN",
+                    message: "Kakao access token is empty."
+                )
+                return
+            }
+
+            self.dispatchSocialLoginResult(
+                provider: "kakao",
+                requestId: requestId,
+                accessToken: accessToken,
+                errorCode: nil,
+                message: nil
+            )
+        }
+
+        if UserApi.isKakaoTalkLoginAvailable() {
+            UserApi.shared.loginWithKakaoTalk(completion: completion)
+        } else {
+            UserApi.shared.loginWithKakaoAccount(completion: completion)
+        }
+    }
+
+    private func dispatchSocialLoginResult(
+        provider: String,
+        requestId: String,
+        accessToken: String?,
+        errorCode: String?,
+        message: String?
+    ) {
+        guard let bridgeViewController = self.window?.rootViewController as? CAPBridgeViewController,
+              let webView = bridgeViewController.webView else {
+            return
+        }
+
+        var payload: [String: Any] = [
+            "provider": provider,
+            "requestId": requestId
+        ]
+
+        if let accessToken {
+            payload["accessToken"] = accessToken
+        }
+        if let errorCode {
+            payload["errorCode"] = errorCode
+        }
+        if let message {
+            payload["message"] = message
+        }
+
+        guard JSONSerialization.isValidJSONObject(payload),
+              let data = try? JSONSerialization.data(withJSONObject: payload),
+              let jsonString = String(data: data, encoding: .utf8) else {
+            return
+        }
+
+        let callbackScript =
+            "window.__CAUSW_ON_NATIVE_SOCIAL_LOGIN__ && window.__CAUSW_ON_NATIVE_SOCIAL_LOGIN__(\(jsonString));"
+        let eventScript =
+            "window.dispatchEvent(new CustomEvent('causw:social-login-result', { detail: \(jsonString) }));"
+
+        DispatchQueue.main.async {
+            webView.evaluateJavaScript(callbackScript, completionHandler: nil)
+            webView.evaluateJavaScript(eventScript, completionHandler: nil)
+        }
+    }
     
     
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
@@ -228,6 +361,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate,UNUserNotificationCenterDe
     }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        if AuthApi.isKakaoTalkLoginUrl(url) {
+            return AuthController.handleOpenUrl(url: url)
+        }
+
         // Called when the app was launched with a url. Feel free to add additional processing here,
         // but if you want the App API to support tracking app url opens, make sure to keep this call
         return ApplicationDelegateProxy.shared.application(app, open: url, options: options)

--- a/apps/web/ios/App/App/AppDelegate.swift
+++ b/apps/web/ios/App/App/AppDelegate.swift
@@ -1,44 +1,44 @@
 import UIKit
 import Capacitor
 import FirebaseCore
-import FirebaseMessaging
-import UserNotifications
-import WebKit
-import AuthenticationServices
 import KakaoSDKCommon
-import KakaoSDKAuth
-import KakaoSDKUser
-import GoogleSignIn
-  // TODO: 어느 정도 개발이 되면 필요한 log찍는 코드 빼고 print문 제거하기
+
 @UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate, WKScriptMessageHandler, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
+class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
-    private var didDetachWebViewConstraints = false
-    private var safeAreaRecalcWorkItem: DispatchWorkItem?
-    private var webViewSafeAreaConstraints: [NSLayoutConstraint] = []
-    private let socialLoginMessageHandlerNames = ["causwSocialLogin", "socialLogin"]
-    private var kakaoNativeAppKey: String {
-        infoPlistString(forKey: "CAUSWKakaoNativeAppKey")
-    }
-    private var googleClientId: String {
-        infoPlistString(forKey: "CAUSWGoogleClientID")
-    }
-    private var pendingAppleRequestId: String?
 
-    private struct SafeAreaSnapshot: Equatable {
-        let size: CGSize
-        let origin: CGPoint
-    }
+    private lazy var safeAreaManager = SafeAreaManager(
+        bridgeViewControllerProvider: { [weak self] in
+            self?.window?.rootViewController as? CAPBridgeViewController
+        }
+    )
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
-        KakaoSDK.initSDK(appKey: kakaoNativeAppKey)
+    private lazy var socialLoginCoordinator = SocialLoginCoordinator(
+        kakaoNativeAppKeyProvider: { [weak self] in
+            self?.infoPlistString(forKey: "CAUSWKakaoNativeAppKey") ?? ""
+        },
+        googleClientIdProvider: { [weak self] in
+            self?.infoPlistString(forKey: "CAUSWGoogleClientID") ?? ""
+        },
+        windowProvider: { [weak self] in
+            self?.window
+        },
+        webViewProvider: { [weak self] in
+            (self?.window?.rootViewController as? CAPBridgeViewController)?.webView
+        }
+    )
+
+    private let pushNotificationHandler = PushNotificationHandler()
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        KakaoSDK.initSDK(appKey: infoPlistString(forKey: "CAUSWKakaoNativeAppKey"))
         FirebaseApp.configure()
-        UNUserNotificationCenter.current().delegate = self
-        
-        //이 문장이 있어야 'didRegisterForRemoteNotifications~~'가 호출됨 
-        application.registerForRemoteNotifications()
+        pushNotificationHandler.configure(application: application)
+
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleDeviceOrientationDidChange),
@@ -58,9 +58,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             object: nil
         )
         UIDevice.current.beginGeneratingDeviceOrientationNotifications()
+
         DispatchQueue.main.async {
             self.configureBridgeWebView()
-            self.startSafeAreaRecalculationCycle()
+            self.safeAreaManager.startSafeAreaRecalculationCycle()
         }
         return true
     }
@@ -70,97 +71,26 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         if isUnsupportedUpsideDownEvent(orientation) {
             return
         }
-        startSafeAreaRecalculationCycle()
+        safeAreaManager.startSafeAreaRecalculationCycle()
     }
 
     @objc private func handleDidBecomeActive() {
-        startSafeAreaRecalculationCycle()
+        safeAreaManager.startSafeAreaRecalculationCycle()
     }
 
     @objc private func handleWillEnterForeground() {
-        startSafeAreaRecalculationCycle()
+        safeAreaManager.startSafeAreaRecalculationCycle()
     }
 
     private func configureBridgeWebView() {
-        guard let bridgeViewController = self.window?.rootViewController as? CAPBridgeViewController,
-              let webView = bridgeViewController.webView else {
+        guard let bridgeViewController = window?.rootViewController as? CAPBridgeViewController,
+              bridgeViewController.webView != nil else {
             return
         }
 
         window?.backgroundColor = .white
-        bridgeViewController.view.backgroundColor = .white
-        webView.allowsBackForwardNavigationGestures = true
-        webView.scrollView.contentInsetAdjustmentBehavior = .never
-        webView.isOpaque = true
-        webView.backgroundColor = .white
-        webView.scrollView.backgroundColor = .white
-        webView.translatesAutoresizingMaskIntoConstraints = false
-        webView.autoresizingMask = []
-        webView.alpha = 1
-        registerSocialLoginMessageHandlers(on: webView)
-
-        if !didDetachWebViewConstraints {
-            detachWebViewConstraints(webView)
-            didDetachWebViewConstraints = true
-        }
-        installSafeAreaConstraintsIfNeeded(webView)
-    }
-
-    private func registerSocialLoginMessageHandlers(on webView: WKWebView) {
-        let userContentController = webView.configuration.userContentController
-        for handlerName in socialLoginMessageHandlerNames {
-            userContentController.removeScriptMessageHandler(forName: handlerName)
-            userContentController.add(self, name: handlerName)
-        }
-    }
-
-    private func startSafeAreaRecalculationCycle() {
-        safeAreaRecalcWorkItem?.cancel()
-        recalculateSafeAreaUntilStable(remainingAttempts: 40, lastSnapshot: nil, stableCount: 0)
-    }
-
-    private func recalculateSafeAreaUntilStable(
-        remainingAttempts: Int,
-        lastSnapshot: SafeAreaSnapshot?,
-        stableCount: Int
-    ) {
-        let workItem = DispatchWorkItem { [weak self] in
-            guard let self else { return }
-            guard let bridgeViewController = self.window?.rootViewController as? CAPBridgeViewController,
-                  let webView = bridgeViewController.webView else {
-                return
-            }
-
-            bridgeViewController.view.layoutIfNeeded()
-            installSafeAreaConstraintsIfNeeded(webView)
-            let hasValidBounds = bridgeViewController.view.bounds.width > 0
-                && bridgeViewController.view.bounds.height > 0
-            let insets = bridgeViewController.view.safeAreaInsets
-            let snapshot = SafeAreaSnapshot(
-                size: CGSize(width: insets.left + insets.right, height: insets.top + insets.bottom),
-                origin: .zero
-            )
-
-            let nextStableCount = (snapshot == lastSnapshot) ? (stableCount + 1) : 1
-            if hasValidBounds && nextStableCount >= 3 {
-                self.setBridgeWebViewVisible(true)
-                return
-            }
-
-            if remainingAttempts <= 0 {
-                self.setBridgeWebViewVisible(true)
-                return
-            }
-
-            self.recalculateSafeAreaUntilStable(
-                remainingAttempts: remainingAttempts - 1,
-                lastSnapshot: snapshot,
-                stableCount: nextStableCount
-            )
-        }
-
-        safeAreaRecalcWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.06, execute: workItem)
+        safeAreaManager.configureBridgeWebViewAppearance()
+        socialLoginCoordinator.registerMessageHandlers()
     }
 
     private func isUnsupportedUpsideDownEvent(_ orientation: UIDeviceOrientation) -> Bool {
@@ -184,426 +114,45 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         return ""
     }
 
-    private func isKakaoLoginCancelled(_ error: Error) -> Bool {
-        if let sdkError = error as? SdkError, sdkError.isClientFailed {
-            return sdkError.getClientError().reason == .Cancelled
-        }
-        let nsError = error as NSError
-        if nsError.code == ASWebAuthenticationSessionError.canceledLogin.rawValue {
-            return true
-        }
-        return nsError.localizedDescription.lowercased().contains("cancel")
-    }
-
-    private func isAppleLoginCancelled(_ error: Error) -> Bool {
-        if let authError = error as? ASAuthorizationError {
-            return authError.code == .canceled
-        }
-        let nsError = error as NSError
-        return nsError.domain == ASAuthorizationError.errorDomain
-            && nsError.code == ASAuthorizationError.canceled.rawValue
-    }
-
-    private func setBridgeWebViewVisible(_ visible: Bool) {
-        guard let bridgeViewController = self.window?.rootViewController as? CAPBridgeViewController,
-              let webView = bridgeViewController.webView else {
-            return
-        }
-        webView.alpha = visible ? 1 : 0
-    }
-
-    private func detachWebViewConstraints(_ webView: UIView) {
-        guard let superview = webView.superview else { return }
-        let relatedConstraints = superview.constraints.filter { constraint in
-            (constraint.firstItem as? UIView) == webView || (constraint.secondItem as? UIView) == webView
-        }
-        NSLayoutConstraint.deactivate(relatedConstraints)
-    }
-
-    private func installSafeAreaConstraintsIfNeeded(_ webView: UIView) {
-        if !webViewSafeAreaConstraints.isEmpty {
-            return
-        }
-        guard let superview = webView.superview else { return }
-        let guide = superview.safeAreaLayoutGuide
-        webViewSafeAreaConstraints = [
-            webView.leadingAnchor.constraint(equalTo: guide.leadingAnchor),
-            webView.trailingAnchor.constraint(equalTo: guide.trailingAnchor),
-            webView.topAnchor.constraint(equalTo: guide.topAnchor),
-            webView.bottomAnchor.constraint(equalTo: guide.bottomAnchor)
-        ]
-        NSLayoutConstraint.activate(webViewSafeAreaConstraints)
-    }
-
-    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        guard socialLoginMessageHandlerNames.contains(message.name) else { return }
-        guard let body = message.body as? [String: Any] else { return }
-
-        let provider = body["provider"] as? String
-        let requestId = body["requestId"] as? String
-
-        guard let provider, let requestId else {
-            dispatchSocialLoginResult(
-                provider: "kakao",
-                requestId: requestId ?? "",
-                accessToken: nil,
-                errorCode: "INVALID_PAYLOAD",
-                message: "Missing provider or requestId."
-            )
-            return
-        }
-
-        switch provider {
-        case "kakao":
-            loginWithKakao(requestId: requestId)
-        case "google":
-            loginWithGoogle(requestId: requestId)
-        case "apple":
-            loginWithApple(requestId: requestId)
-        default:
-            dispatchSocialLoginResult(
-                provider: provider,
-                requestId: requestId,
-                accessToken: nil,
-                errorCode: "UNSUPPORTED_PROVIDER",
-                message: "Unsupported provider on iOS bridge."
-            )
-        }
-    }
-
-    private func loginWithKakao(requestId: String) {
-        let completion: (OAuthToken?, Error?) -> Void = { [weak self] token, error in
-            guard let self else { return }
-            if let error {
-                if self.isKakaoLoginCancelled(error) {
-                    self.dispatchSocialLoginResult(
-                        provider: "kakao",
-                        requestId: requestId,
-                        accessToken: nil,
-                        errorCode: "KAKAO_LOGIN_CANCELLED",
-                        message: "Kakao login cancelled."
-                    )
-                    return
-                }
-                self.dispatchSocialLoginResult(
-                    provider: "kakao",
-                    requestId: requestId,
-                    accessToken: nil,
-                    errorCode: "KAKAO_LOGIN_FAILED",
-                    message: error.localizedDescription
-                )
-                return
-            }
-
-            guard let accessToken = token?.accessToken, !accessToken.isEmpty else {
-                self.dispatchSocialLoginResult(
-                    provider: "kakao",
-                    requestId: requestId,
-                    accessToken: nil,
-                    errorCode: "EMPTY_ACCESS_TOKEN",
-                    message: "Kakao access token is empty."
-                )
-                return
-            }
-
-            self.dispatchSocialLoginResult(
-                provider: "kakao",
-                requestId: requestId,
-                accessToken: accessToken,
-                errorCode: nil,
-                message: nil
-            )
-        }
-
-        if UserApi.isKakaoTalkLoginAvailable() {
-            UserApi.shared.loginWithKakaoTalk(completion: completion)
-        } else {
-            UserApi.shared.loginWithKakaoAccount(completion: completion)
-        }
-    }
-
-    private func loginWithGoogle(requestId: String) {
-        guard !googleClientId.isEmpty else {
-            dispatchSocialLoginResult(
-                provider: "google",
-                requestId: requestId,
-                accessToken: nil,
-                errorCode: "GOOGLE_CLIENT_ID_MISSING",
-                message: "Google client id is missing."
-            )
-            return
-        }
-
-        guard let rootViewController = window?.rootViewController else {
-            dispatchSocialLoginResult(
-                provider: "google",
-                requestId: requestId,
-                accessToken: nil,
-                errorCode: "PRESENTING_VIEW_CONTROLLER_MISSING",
-                message: "Unable to find presenting view controller."
-            )
-            return
-        }
-
-        GIDSignIn.sharedInstance.configuration = GIDConfiguration(clientID: googleClientId)
-
-        GIDSignIn.sharedInstance.signIn(withPresenting: rootViewController) { [weak self] result, error in
-            guard let self else { return }
-
-            if let error {
-                self.dispatchSocialLoginResult(
-                    provider: "google",
-                    requestId: requestId,
-                    accessToken: nil,
-                    errorCode: "GOOGLE_LOGIN_FAILED",
-                    message: error.localizedDescription
-                )
-                return
-            }
-
-            guard let accessToken = result?.user.accessToken.tokenString,
-                  !accessToken.isEmpty else {
-                self.dispatchSocialLoginResult(
-                    provider: "google",
-                    requestId: requestId,
-                    accessToken: nil,
-                    errorCode: "EMPTY_ACCESS_TOKEN",
-                    message: "Google access token is empty."
-                )
-                return
-            }
-
-            self.dispatchSocialLoginResult(
-                provider: "google",
-                requestId: requestId,
-                accessToken: accessToken,
-                errorCode: nil,
-                message: nil
-            )
-        }
-    }
-
-    private func loginWithApple(requestId: String) {
-        if #available(iOS 13.0, *) {
-            pendingAppleRequestId = requestId
-
-            let provider = ASAuthorizationAppleIDProvider()
-            let request = provider.createRequest()
-            request.requestedScopes = [.fullName, .email]
-
-            let authorizationController = ASAuthorizationController(authorizationRequests: [request])
-            authorizationController.delegate = self
-            authorizationController.presentationContextProvider = self
-            authorizationController.performRequests()
-            return
-        }
-
-        dispatchSocialLoginResult(
-            provider: "apple",
-            requestId: requestId,
-            accessToken: nil,
-            errorCode: "APPLE_LOGIN_UNAVAILABLE",
-            message: "Apple login requires iOS 13 or later."
-        )
-    }
-
-    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
-        guard let requestId = pendingAppleRequestId else { return }
-        pendingAppleRequestId = nil
-
-        guard let appleCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
-            dispatchSocialLoginResult(
-                provider: "apple",
-                requestId: requestId,
-                accessToken: nil,
-                errorCode: "APPLE_CREDENTIAL_MISSING",
-                message: "Apple credential is missing."
-            )
-            return
-        }
-
-        guard let identityTokenData = appleCredential.identityToken,
-              let identityToken = String(data: identityTokenData, encoding: .utf8),
-              !identityToken.isEmpty else {
-            dispatchSocialLoginResult(
-                provider: "apple",
-                requestId: requestId,
-                accessToken: nil,
-                errorCode: "EMPTY_ACCESS_TOKEN",
-                message: "Apple identity token is empty."
-            )
-            return
-        }
-
-        dispatchSocialLoginResult(
-            provider: "apple",
-            requestId: requestId,
-            accessToken: identityToken,
-            errorCode: nil,
-            message: nil
-        )
-    }
-
-    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-        guard let requestId = pendingAppleRequestId else { return }
-        pendingAppleRequestId = nil
-
-        if isAppleLoginCancelled(error) {
-            dispatchSocialLoginResult(
-                provider: "apple",
-                requestId: requestId,
-                accessToken: nil,
-                errorCode: "APPLE_LOGIN_CANCELLED",
-                message: "Apple login cancelled."
-            )
-            return
-        }
-
-        dispatchSocialLoginResult(
-            provider: "apple",
-            requestId: requestId,
-            accessToken: nil,
-            errorCode: "APPLE_LOGIN_FAILED",
-            message: error.localizedDescription
-        )
-    }
-
-    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        return window ?? ASPresentationAnchor()
-    }
-
-    private func dispatchSocialLoginResult(
-        provider: String,
-        requestId: String,
-        accessToken: String?,
-        errorCode: String?,
-        message: String?
-    ) {
-        guard let bridgeViewController = self.window?.rootViewController as? CAPBridgeViewController,
-              let webView = bridgeViewController.webView else {
-            return
-        }
-
-        var payload: [String: Any] = [
-            "provider": provider,
-            "requestId": requestId
-        ]
-
-        if let accessToken {
-            payload["accessToken"] = accessToken
-        }
-        if let errorCode {
-            payload["errorCode"] = errorCode
-        }
-        if let message {
-            payload["message"] = message
-        }
-
-        guard JSONSerialization.isValidJSONObject(payload),
-              let data = try? JSONSerialization.data(withJSONObject: payload),
-              let jsonString = String(data: data, encoding: .utf8) else {
-            return
-        }
-
-        let callbackScript =
-            "window.__CAUSW_ON_NATIVE_SOCIAL_LOGIN__ && window.__CAUSW_ON_NATIVE_SOCIAL_LOGIN__(\(jsonString));"
-        let eventScript =
-            "window.dispatchEvent(new CustomEvent('causw:social-login-result', { detail: \(jsonString) }));"
-
-        DispatchQueue.main.async {
-            self.startSafeAreaRecalculationCycle()
-            webView.evaluateJavaScript(callbackScript, completionHandler: nil)
-            webView.evaluateJavaScript(eventScript, completionHandler: nil)
-        }
-    }
-    
-    
-    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-            
-            //  알림이 잘 왔는지 확인하는 로그
-            let userInfo = notification.request.content.userInfo
-        
-            // Firebase Messaging에 알림 정보를 전달합니다.
-            Messaging.messaging().appDidReceiveMessage(userInfo)
-            
-            // 알림을 화면에 표시합니다.
-            completionHandler([.alert, .sound, .badge])
-        }
-    //사용자가 알림을 탭했을 때 호출됩니다.
-       func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-           
-           //  알림 탭 액션 로그
-           let userInfo = response.notification.request.content.userInfo
-         
-           
-           // Firebase Messaging에 알림 정보를 전달합니다.
-           Messaging.messaging().appDidReceiveMessage(userInfo)
-           
-           completionHandler()
-       }
-    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        print("📍 APNs 등록 성공! 토큰 생성 시작...")
-        Messaging.messaging().apnsToken = deviceToken
-        Messaging.messaging().token(completion: { (token, error) in
-            if let error = error {
-                NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
-            print("FCM 토큰 에러: \(error)\(error.localizedDescription)")
-            } else if let token = token {
-                NotificationCenter.default.post(name: .capacitorDidRegisterForRemoteNotifications, object: token)
-            print("FCM 토큰: \(token)")
-            }
-        })
-    }
-
-    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
-       print("❌ APNs 등록 실패: \(error.localizedDescription)")
-      NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
-    }
-    func applicationWillResignActive(_ application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
-    }
-
-    func applicationDidEnterBackground(_ application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-    }
-
-    func applicationWillEnterForeground(_ application: UIApplication) {
-        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
-    }
-
-    func applicationDidBecomeActive(_ application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-    }
-
     func applicationWillTerminate(_ application: UIApplication) {
-        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-        safeAreaRecalcWorkItem?.cancel()
         UIDevice.current.endGeneratingDeviceOrientationNotifications()
         NotificationCenter.default.removeObserver(self)
     }
 
-    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-        startSafeAreaRecalculationCycle()
-        if GIDSignIn.sharedInstance.handle(url) {
+    func application(
+        _ app: UIApplication,
+        open url: URL,
+        options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+    ) -> Bool {
+        if socialLoginCoordinator.handleOpenURL(url) {
             return true
         }
-
-        if AuthApi.isKakaoTalkLoginUrl(url) {
-            return AuthController.handleOpenUrl(url: url)
-        }
-
-        // Called when the app was launched with a url. Feel free to add additional processing here,
-        // but if you want the App API to support tracking app url opens, make sure to keep this call
         return ApplicationDelegateProxy.shared.application(app, open: url, options: options)
     }
 
-    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-        // Called when the app was launched with an activity, including Universal Links.
-        // Feel free to add additional processing here, but if you want the App API to support
-        // tracking app url opens, make sure to keep this call
-        return ApplicationDelegateProxy.shared.application(application, continue: userActivity, restorationHandler: restorationHandler)
+    func application(
+        _ application: UIApplication,
+        continue userActivity: NSUserActivity,
+        restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+    ) -> Bool {
+        return ApplicationDelegateProxy.shared.application(
+            application,
+            continue: userActivity,
+            restorationHandler: restorationHandler
+        )
     }
 
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        pushNotificationHandler.didRegisterForRemoteNotifications(with: deviceToken)
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        pushNotificationHandler.didFailToRegisterForRemoteNotifications(with: error)
+    }
 }

--- a/apps/web/ios/App/App/AppDelegate.swift
+++ b/apps/web/ios/App/App/AppDelegate.swift
@@ -16,6 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     var window: UIWindow?
     private var didDetachWebViewConstraints = false
     private var safeAreaRecalcWorkItem: DispatchWorkItem?
+    private var webViewSafeAreaConstraints: [NSLayoutConstraint] = []
     private let socialLoginMessageHandlerNames = ["causwSocialLogin", "socialLogin"]
     private let kakaoNativeAppKey = "4535709d7c684cff31a42bb2b522eed9"
     private let googleClientId = "1086770319771-cnj8h70c5lc29ljijcaif27cnb93lq1e.apps.googleusercontent.com"
@@ -46,6 +47,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             name: UIApplication.didBecomeActiveNotification,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleWillEnterForeground),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
         UIDevice.current.beginGeneratingDeviceOrientationNotifications()
         DispatchQueue.main.async {
             self.configureBridgeWebView()
@@ -66,6 +73,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         startSafeAreaRecalculationCycle()
     }
 
+    @objc private func handleWillEnterForeground() {
+        startSafeAreaRecalculationCycle()
+    }
+
     private func configureBridgeWebView() {
         guard let bridgeViewController = self.window?.rootViewController as? CAPBridgeViewController,
               let webView = bridgeViewController.webView else {
@@ -79,15 +90,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         webView.isOpaque = true
         webView.backgroundColor = .white
         webView.scrollView.backgroundColor = .white
-        webView.translatesAutoresizingMaskIntoConstraints = true
+        webView.translatesAutoresizingMaskIntoConstraints = false
         webView.autoresizingMask = []
-        webView.alpha = 0
+        webView.alpha = 1
         registerSocialLoginMessageHandlers(on: webView)
 
         if !didDetachWebViewConstraints {
             detachWebViewConstraints(webView)
             didDetachWebViewConstraints = true
         }
+        installSafeAreaConstraintsIfNeeded(webView)
     }
 
     private func registerSocialLoginMessageHandlers(on webView: WKWebView) {
@@ -100,7 +112,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     private func startSafeAreaRecalculationCycle() {
         safeAreaRecalcWorkItem?.cancel()
-        setBridgeWebViewVisible(false)
         recalculateSafeAreaUntilStable(remainingAttempts: 40, lastSnapshot: nil, stableCount: 0)
     }
 
@@ -117,25 +128,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             }
 
             bridgeViewController.view.layoutIfNeeded()
-            let safeFrameInBridge = bridgeViewController.view.safeAreaLayoutGuide.layoutFrame
-
-            let hasValidBounds = safeFrameInBridge.width > 0 && safeFrameInBridge.height > 0
+            installSafeAreaConstraintsIfNeeded(webView)
+            let hasValidBounds = bridgeViewController.view.bounds.width > 0
+                && bridgeViewController.view.bounds.height > 0
+            let insets = bridgeViewController.view.safeAreaInsets
             let snapshot = SafeAreaSnapshot(
-                size: safeFrameInBridge.size,
-                origin: safeFrameInBridge.origin
+                size: CGSize(width: insets.left + insets.right, height: insets.top + insets.bottom),
+                origin: .zero
             )
 
             let nextStableCount = (snapshot == lastSnapshot) ? (stableCount + 1) : 1
             if hasValidBounds && nextStableCount >= 3 {
-                webView.frame = safeFrameInBridge
                 self.setBridgeWebViewVisible(true)
                 return
             }
 
             if remainingAttempts <= 0 {
-                if hasValidBounds {
-                    webView.frame = safeFrameInBridge
-                }
                 self.setBridgeWebViewVisible(true)
                 return
             }
@@ -178,6 +186,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             (constraint.firstItem as? UIView) == webView || (constraint.secondItem as? UIView) == webView
         }
         NSLayoutConstraint.deactivate(relatedConstraints)
+    }
+
+    private func installSafeAreaConstraintsIfNeeded(_ webView: UIView) {
+        if !webViewSafeAreaConstraints.isEmpty {
+            return
+        }
+        guard let superview = webView.superview else { return }
+        let guide = superview.safeAreaLayoutGuide
+        webViewSafeAreaConstraints = [
+            webView.leadingAnchor.constraint(equalTo: guide.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: guide.trailingAnchor),
+            webView.topAnchor.constraint(equalTo: guide.topAnchor),
+            webView.bottomAnchor.constraint(equalTo: guide.bottomAnchor)
+        ]
+        NSLayoutConstraint.activate(webViewSafeAreaConstraints)
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
@@ -435,6 +458,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             "window.dispatchEvent(new CustomEvent('causw:social-login-result', { detail: \(jsonString) }));"
 
         DispatchQueue.main.async {
+            self.startSafeAreaRecalculationCycle()
             webView.evaluateJavaScript(callbackScript, completionHandler: nil)
             webView.evaluateJavaScript(eventScript, completionHandler: nil)
         }
@@ -508,6 +532,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        startSafeAreaRecalculationCycle()
         if GIDSignIn.sharedInstance.handle(url) {
             return true
         }

--- a/apps/web/ios/App/App/Info.plist
+++ b/apps/web/ios/App/App/Info.plist
@@ -18,6 +18,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>kakao4535709d7c684cff31a42bb2b522eed9</string>
+				<string>com.googleusercontent.apps.1079571986006-lm19q7c395k7mvabrkq8vr64ci9qvb5i</string>
 			</array>
 		</dict>
 	</array>

--- a/apps/web/ios/App/App/Info.plist
+++ b/apps/web/ios/App/App/Info.plist
@@ -22,6 +22,10 @@
 			</array>
 		</dict>
 	</array>
+	<key>CAUSWGoogleClientID</key>
+	<string>1086770319771-cnj8h70c5lc29ljijcaif27cnb93lq1e.apps.googleusercontent.com</string>
+	<key>CAUSWKakaoNativeAppKey</key>
+	<string>4535709d7c684cff31a42bb2b522eed9</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/apps/web/ios/App/App/Info.plist
+++ b/apps/web/ios/App/App/Info.plist
@@ -18,7 +18,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>kakao4535709d7c684cff31a42bb2b522eed9</string>
-				<string>com.googleusercontent.apps.1079571986006-lm19q7c395k7mvabrkq8vr64ci9qvb5i</string>
+				<string>com.googleusercontent.apps.1086770319771-cnj8h70c5lc29ljijcaif27cnb93lq1e</string>
 			</array>
 		</dict>
 	</array>

--- a/apps/web/ios/App/App/Info.plist
+++ b/apps/web/ios/App/App/Info.plist
@@ -10,6 +10,17 @@
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao4535709d7c684cff31a42bb2b522eed9</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -24,6 +35,11 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+	</array>
 	<key>NSCameraUsageDescription</key>
 	<string>프로필 사진을 촬영하기 위해 카메라 접근 권한이 필요합니다.</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/apps/web/ios/App/App/PushNotificationHandler.swift
+++ b/apps/web/ios/App/App/PushNotificationHandler.swift
@@ -1,0 +1,49 @@
+import UIKit
+import FirebaseMessaging
+import UserNotifications
+
+final class PushNotificationHandler: NSObject, UNUserNotificationCenterDelegate {
+    func configure(application: UIApplication) {
+        UNUserNotificationCenter.current().delegate = self
+        application.registerForRemoteNotifications()
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        let userInfo = notification.request.content.userInfo
+        Messaging.messaging().appDidReceiveMessage(userInfo)
+        completionHandler([.alert, .sound, .badge])
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let userInfo = response.notification.request.content.userInfo
+        Messaging.messaging().appDidReceiveMessage(userInfo)
+        completionHandler()
+    }
+
+    func didRegisterForRemoteNotifications(with deviceToken: Data) {
+        print("📍 APNs 등록 성공! 토큰 생성 시작...")
+        Messaging.messaging().apnsToken = deviceToken
+        Messaging.messaging().token(completion: { (token, error) in
+            if let error = error {
+                NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
+                print("FCM 토큰 에러: \(error)\(error.localizedDescription)")
+            } else if let token = token {
+                NotificationCenter.default.post(name: .capacitorDidRegisterForRemoteNotifications, object: token)
+                print("FCM 토큰: \(token)")
+            }
+        })
+    }
+
+    func didFailToRegisterForRemoteNotifications(with error: Error) {
+        print("❌ APNs 등록 실패: \(error.localizedDescription)")
+        NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
+    }
+}

--- a/apps/web/ios/App/App/SafeAreaManager.swift
+++ b/apps/web/ios/App/App/SafeAreaManager.swift
@@ -1,0 +1,112 @@
+import UIKit
+import Capacitor
+
+final class SafeAreaManager {
+    private var didDetachWebViewConstraints = false
+    private var safeAreaRecalcWorkItem: DispatchWorkItem?
+    private var webViewSafeAreaConstraints: [NSLayoutConstraint] = []
+
+    private let bridgeViewControllerProvider: () -> CAPBridgeViewController?
+
+    init(bridgeViewControllerProvider: @escaping () -> CAPBridgeViewController?) {
+        self.bridgeViewControllerProvider = bridgeViewControllerProvider
+    }
+
+    func configureBridgeWebViewAppearance() {
+        guard let bridgeViewController = bridgeViewControllerProvider(),
+              let webView = bridgeViewController.webView else {
+            return
+        }
+
+        bridgeViewController.view.backgroundColor = .white
+        webView.allowsBackForwardNavigationGestures = true
+        webView.scrollView.contentInsetAdjustmentBehavior = .never
+        webView.isOpaque = true
+        webView.backgroundColor = .white
+        webView.scrollView.backgroundColor = .white
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        webView.autoresizingMask = []
+        webView.alpha = 1
+
+        if !didDetachWebViewConstraints {
+            detachWebViewConstraints(webView)
+            didDetachWebViewConstraints = true
+        }
+        installSafeAreaConstraintsIfNeeded(webView)
+    }
+
+    func startSafeAreaRecalculationCycle() {
+        safeAreaRecalcWorkItem?.cancel()
+        recalculateSafeAreaUntilStable(remainingAttempts: 40, lastSnapshot: nil, stableCount: 0)
+    }
+
+    private func recalculateSafeAreaUntilStable(
+        remainingAttempts: Int,
+        lastSnapshot: SafeAreaSnapshot?,
+        stableCount: Int
+    ) {
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            guard let bridgeViewController = self.bridgeViewControllerProvider(),
+                  let webView = bridgeViewController.webView else {
+                return
+            }
+
+            bridgeViewController.view.layoutIfNeeded()
+            self.installSafeAreaConstraintsIfNeeded(webView)
+            let hasValidBounds = bridgeViewController.view.bounds.width > 0
+                && bridgeViewController.view.bounds.height > 0
+            let insets = bridgeViewController.view.safeAreaInsets
+            let snapshot = SafeAreaSnapshot(
+                size: CGSize(width: insets.left + insets.right, height: insets.top + insets.bottom),
+                origin: .zero
+            )
+
+            let nextStableCount = (snapshot == lastSnapshot) ? (stableCount + 1) : 1
+            if hasValidBounds && nextStableCount >= 3 {
+                return
+            }
+
+            if remainingAttempts <= 0 {
+                return
+            }
+
+            self.recalculateSafeAreaUntilStable(
+                remainingAttempts: remainingAttempts - 1,
+                lastSnapshot: snapshot,
+                stableCount: nextStableCount
+            )
+        }
+
+        safeAreaRecalcWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.06, execute: workItem)
+    }
+
+    private func detachWebViewConstraints(_ webView: UIView) {
+        guard let superview = webView.superview else { return }
+        let relatedConstraints = superview.constraints.filter { constraint in
+            (constraint.firstItem as? UIView) == webView || (constraint.secondItem as? UIView) == webView
+        }
+        NSLayoutConstraint.deactivate(relatedConstraints)
+    }
+
+    private func installSafeAreaConstraintsIfNeeded(_ webView: UIView) {
+        if !webViewSafeAreaConstraints.isEmpty {
+            return
+        }
+        guard let superview = webView.superview else { return }
+        let guide = superview.safeAreaLayoutGuide
+        webViewSafeAreaConstraints = [
+            webView.leadingAnchor.constraint(equalTo: guide.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: guide.trailingAnchor),
+            webView.topAnchor.constraint(equalTo: guide.topAnchor),
+            webView.bottomAnchor.constraint(equalTo: guide.bottomAnchor)
+        ]
+        NSLayoutConstraint.activate(webViewSafeAreaConstraints)
+    }
+
+    private struct SafeAreaSnapshot: Equatable {
+        let size: CGSize
+        let origin: CGPoint
+    }
+}

--- a/apps/web/ios/App/App/SocialLoginCoordinator.swift
+++ b/apps/web/ios/App/App/SocialLoginCoordinator.swift
@@ -1,0 +1,349 @@
+import UIKit
+import WebKit
+import AuthenticationServices
+import KakaoSDKUser
+import KakaoSDKAuth
+import KakaoSDKCommon
+import GoogleSignIn
+
+final class SocialLoginCoordinator: NSObject, WKScriptMessageHandler, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
+    private let socialLoginMessageHandlerNames = ["causwSocialLogin", "socialLogin"]
+    private let kakaoNativeAppKeyProvider: () -> String
+    private let googleClientIdProvider: () -> String
+    private let windowProvider: () -> UIWindow?
+    private let webViewProvider: () -> WKWebView?
+
+    private var pendingAppleRequestId: String?
+
+    init(
+        kakaoNativeAppKeyProvider: @escaping () -> String,
+        googleClientIdProvider: @escaping () -> String,
+        windowProvider: @escaping () -> UIWindow?,
+        webViewProvider: @escaping () -> WKWebView?
+    ) {
+        self.kakaoNativeAppKeyProvider = kakaoNativeAppKeyProvider
+        self.googleClientIdProvider = googleClientIdProvider
+        self.windowProvider = windowProvider
+        self.webViewProvider = webViewProvider
+    }
+
+    func registerMessageHandlers() {
+        guard let webView = webViewProvider() else { return }
+        let userContentController = webView.configuration.userContentController
+        for handlerName in socialLoginMessageHandlerNames {
+            userContentController.removeScriptMessageHandler(forName: handlerName)
+            userContentController.add(self, name: handlerName)
+        }
+    }
+
+    func handleOpenURL(_ url: URL) -> Bool {
+        if GIDSignIn.sharedInstance.handle(url) {
+            return true
+        }
+        if AuthApi.isKakaoTalkLoginUrl(url) {
+            return AuthController.handleOpenUrl(url: url)
+        }
+        return false
+    }
+
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard socialLoginMessageHandlerNames.contains(message.name) else { return }
+        guard let body = message.body as? [String: Any] else { return }
+
+        let provider = body["provider"] as? String
+        let requestId = body["requestId"] as? String
+
+        guard let provider, let requestId else {
+            dispatchSocialLoginResult(
+                provider: "kakao",
+                requestId: requestId ?? "",
+                accessToken: nil,
+                errorCode: "INVALID_PAYLOAD",
+                message: "Missing provider or requestId."
+            )
+            return
+        }
+
+        switch provider {
+        case "kakao":
+            loginWithKakao(requestId: requestId)
+        case "google":
+            loginWithGoogle(requestId: requestId)
+        case "apple":
+            loginWithApple(requestId: requestId)
+        default:
+            dispatchSocialLoginResult(
+                provider: provider,
+                requestId: requestId,
+                accessToken: nil,
+                errorCode: "UNSUPPORTED_PROVIDER",
+                message: "Unsupported provider on iOS bridge."
+            )
+        }
+    }
+
+    private func loginWithKakao(requestId: String) {
+        let completion: (OAuthToken?, Error?) -> Void = { [weak self] token, error in
+            guard let self else { return }
+            if let error {
+                if self.isKakaoLoginCancelled(error) {
+                    self.dispatchSocialLoginResult(
+                        provider: "kakao",
+                        requestId: requestId,
+                        accessToken: nil,
+                        errorCode: "KAKAO_LOGIN_CANCELLED",
+                        message: "Kakao login cancelled."
+                    )
+                    return
+                }
+                self.dispatchSocialLoginResult(
+                    provider: "kakao",
+                    requestId: requestId,
+                    accessToken: nil,
+                    errorCode: "KAKAO_LOGIN_FAILED",
+                    message: error.localizedDescription
+                )
+                return
+            }
+
+            guard let accessToken = token?.accessToken, !accessToken.isEmpty else {
+                self.dispatchSocialLoginResult(
+                    provider: "kakao",
+                    requestId: requestId,
+                    accessToken: nil,
+                    errorCode: "EMPTY_ACCESS_TOKEN",
+                    message: "Kakao access token is empty."
+                )
+                return
+            }
+
+            self.dispatchSocialLoginResult(
+                provider: "kakao",
+                requestId: requestId,
+                accessToken: accessToken,
+                errorCode: nil,
+                message: nil
+            )
+        }
+
+        if UserApi.isKakaoTalkLoginAvailable() {
+            UserApi.shared.loginWithKakaoTalk(completion: completion)
+        } else {
+            UserApi.shared.loginWithKakaoAccount(completion: completion)
+        }
+    }
+
+    private func loginWithGoogle(requestId: String) {
+        let googleClientId = googleClientIdProvider()
+        guard !googleClientId.isEmpty else {
+            dispatchSocialLoginResult(
+                provider: "google",
+                requestId: requestId,
+                accessToken: nil,
+                errorCode: "GOOGLE_CLIENT_ID_MISSING",
+                message: "Google client id is missing."
+            )
+            return
+        }
+
+        guard let rootViewController = windowProvider()?.rootViewController else {
+            dispatchSocialLoginResult(
+                provider: "google",
+                requestId: requestId,
+                accessToken: nil,
+                errorCode: "PRESENTING_VIEW_CONTROLLER_MISSING",
+                message: "Unable to find presenting view controller."
+            )
+            return
+        }
+
+        GIDSignIn.sharedInstance.configuration = GIDConfiguration(clientID: googleClientId)
+
+        GIDSignIn.sharedInstance.signIn(withPresenting: rootViewController) { [weak self] result, error in
+            guard let self else { return }
+
+            if let error {
+                self.dispatchSocialLoginResult(
+                    provider: "google",
+                    requestId: requestId,
+                    accessToken: nil,
+                    errorCode: "GOOGLE_LOGIN_FAILED",
+                    message: error.localizedDescription
+                )
+                return
+            }
+
+            guard let accessToken = result?.user.accessToken.tokenString,
+                  !accessToken.isEmpty else {
+                self.dispatchSocialLoginResult(
+                    provider: "google",
+                    requestId: requestId,
+                    accessToken: nil,
+                    errorCode: "EMPTY_ACCESS_TOKEN",
+                    message: "Google access token is empty."
+                )
+                return
+            }
+
+            self.dispatchSocialLoginResult(
+                provider: "google",
+                requestId: requestId,
+                accessToken: accessToken,
+                errorCode: nil,
+                message: nil
+            )
+        }
+    }
+
+    private func loginWithApple(requestId: String) {
+        if #available(iOS 13.0, *) {
+            pendingAppleRequestId = requestId
+
+            let provider = ASAuthorizationAppleIDProvider()
+            let request = provider.createRequest()
+            request.requestedScopes = [.fullName, .email]
+
+            let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+            authorizationController.delegate = self
+            authorizationController.presentationContextProvider = self
+            authorizationController.performRequests()
+            return
+        }
+
+        dispatchSocialLoginResult(
+            provider: "apple",
+            requestId: requestId,
+            accessToken: nil,
+            errorCode: "APPLE_LOGIN_UNAVAILABLE",
+            message: "Apple login requires iOS 13 or later."
+        )
+    }
+
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        guard let requestId = pendingAppleRequestId else { return }
+        pendingAppleRequestId = nil
+
+        guard let appleCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+            dispatchSocialLoginResult(
+                provider: "apple",
+                requestId: requestId,
+                accessToken: nil,
+                errorCode: "APPLE_CREDENTIAL_MISSING",
+                message: "Apple credential is missing."
+            )
+            return
+        }
+
+        guard let identityTokenData = appleCredential.identityToken,
+              let identityToken = String(data: identityTokenData, encoding: .utf8),
+              !identityToken.isEmpty else {
+            dispatchSocialLoginResult(
+                provider: "apple",
+                requestId: requestId,
+                accessToken: nil,
+                errorCode: "EMPTY_ACCESS_TOKEN",
+                message: "Apple identity token is empty."
+            )
+            return
+        }
+
+        dispatchSocialLoginResult(
+            provider: "apple",
+            requestId: requestId,
+            accessToken: identityToken,
+            errorCode: nil,
+            message: nil
+        )
+    }
+
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        guard let requestId = pendingAppleRequestId else { return }
+        pendingAppleRequestId = nil
+
+        if isAppleLoginCancelled(error) {
+            dispatchSocialLoginResult(
+                provider: "apple",
+                requestId: requestId,
+                accessToken: nil,
+                errorCode: "APPLE_LOGIN_CANCELLED",
+                message: "Apple login cancelled."
+            )
+            return
+        }
+
+        dispatchSocialLoginResult(
+            provider: "apple",
+            requestId: requestId,
+            accessToken: nil,
+            errorCode: "APPLE_LOGIN_FAILED",
+            message: error.localizedDescription
+        )
+    }
+
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return windowProvider() ?? ASPresentationAnchor()
+    }
+
+    private func dispatchSocialLoginResult(
+        provider: String,
+        requestId: String,
+        accessToken: String?,
+        errorCode: String?,
+        message: String?
+    ) {
+        guard let webView = webViewProvider() else {
+            return
+        }
+
+        var payload: [String: Any] = [
+            "provider": provider,
+            "requestId": requestId
+        ]
+
+        if let accessToken {
+            payload["accessToken"] = accessToken
+        }
+        if let errorCode {
+            payload["errorCode"] = errorCode
+        }
+        if let message {
+            payload["message"] = message
+        }
+
+        guard JSONSerialization.isValidJSONObject(payload),
+              let data = try? JSONSerialization.data(withJSONObject: payload),
+              let jsonString = String(data: data, encoding: .utf8) else {
+            return
+        }
+
+        let callbackScript =
+            "window.__CAUSW_ON_NATIVE_SOCIAL_LOGIN__ && window.__CAUSW_ON_NATIVE_SOCIAL_LOGIN__(\(jsonString));"
+        let eventScript =
+            "window.dispatchEvent(new CustomEvent('causw:social-login-result', { detail: \(jsonString) }));"
+
+        DispatchQueue.main.async {
+            webView.evaluateJavaScript(callbackScript, completionHandler: nil)
+            webView.evaluateJavaScript(eventScript, completionHandler: nil)
+        }
+    }
+
+    private func isKakaoLoginCancelled(_ error: Error) -> Bool {
+        if let sdkError = error as? SdkError, sdkError.isClientFailed {
+            return sdkError.getClientError().reason == .Cancelled
+        }
+        let nsError = error as NSError
+        if nsError.code == ASWebAuthenticationSessionError.canceledLogin.rawValue {
+            return true
+        }
+        return nsError.localizedDescription.lowercased().contains("cancel")
+    }
+
+    private func isAppleLoginCancelled(_ error: Error) -> Bool {
+        if let authError = error as? ASAuthorizationError {
+            return authError.code == .canceled
+        }
+        let nsError = error as NSError
+        return nsError.domain == ASAuthorizationError.errorDomain
+            && nsError.code == ASAuthorizationError.canceled.rawValue
+    }
+}

--- a/apps/web/ios/App/Podfile
+++ b/apps/web/ios/App/Podfile
@@ -21,6 +21,8 @@ target 'App' do
   capacitor_pods
   # Add your Pods here
   pod 'Firebase/Messaging'
+  pod 'KakaoSDKAuth'
+  pod 'KakaoSDKUser'
 end
 
 post_install do |installer|

--- a/apps/web/ios/App/Podfile
+++ b/apps/web/ios/App/Podfile
@@ -23,6 +23,7 @@ target 'App' do
   pod 'Firebase/Messaging'
   pod 'KakaoSDKAuth'
   pod 'KakaoSDKUser'
+  pod 'GoogleSignIn'
 end
 
 post_install do |installer|

--- a/apps/web/ios/App/Podfile.lock
+++ b/apps/web/ios/App/Podfile.lock
@@ -1,4 +1,5 @@
 PODS:
+  - Alamofire (5.9.1)
   - Capacitor (7.4.2):
     - CapacitorCordova
   - CapacitorApp (7.1.2):
@@ -63,6 +64,17 @@ PODS:
   - GoogleUtilities/UserDefaults (8.1.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
+  - KakaoSDKAuth (2.22.7):
+    - KakaoSDKCommon (= 2.22.7)
+  - KakaoSDKCommon (2.22.7):
+    - KakaoSDKCommon/Common (= 2.22.7)
+    - KakaoSDKCommon/Network (= 2.22.7)
+  - KakaoSDKCommon/Common (2.22.7)
+  - KakaoSDKCommon/Network (2.22.7):
+    - Alamofire (~> 5.9.0)
+    - KakaoSDKCommon/Common (= 2.22.7)
+  - KakaoSDKUser (2.22.7):
+    - KakaoSDKAuth (= 2.22.7)
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
@@ -79,9 +91,12 @@ DEPENDENCIES:
   - "CapacitorSecureStoragePlugin (from `../../../../node_modules/.pnpm/capacitor-secure-storage-plugin@0.12.0_@capacitor+core@7.4.2/node_modules/capacitor-secure-storage-plugin`)"
   - "CapacitorStatusBar (from `../../../../node_modules/.pnpm/@capacitor+status-bar@7.0.5_@capacitor+core@7.4.2/node_modules/@capacitor/status-bar`)"
   - Firebase/Messaging
+  - KakaoSDKAuth
+  - KakaoSDKUser
 
 SPEC REPOS:
   trunk:
+    - Alamofire
     - Firebase
     - FirebaseCore
     - FirebaseCoreInternal
@@ -89,6 +104,9 @@ SPEC REPOS:
     - FirebaseMessaging
     - GoogleDataTransport
     - GoogleUtilities
+    - KakaoSDKAuth
+    - KakaoSDKCommon
+    - KakaoSDKUser
     - nanopb
     - PromisesObjC
     - SwiftKeychainWrapper
@@ -108,6 +126,7 @@ EXTERNAL SOURCES:
     :path: "../../../../node_modules/.pnpm/@capacitor+status-bar@7.0.5_@capacitor+core@7.4.2/node_modules/@capacitor/status-bar"
 
 SPEC CHECKSUMS:
+  Alamofire: f36a35757af4587d8e4f4bfa223ad10be2422b8c
   Capacitor: 9d9e481b79ffaeacaf7a85d6a11adec32bd33b59
   CapacitorApp: f01a913211780e0718dae9750442c3e23f96e106
   CapacitorCordova: 5e58d04631bc5094894ac106e2bf1da18a9e6151
@@ -121,10 +140,13 @@ SPEC CHECKSUMS:
   FirebaseMessaging: 3b26e2cee503815e01c3701236b020aa9b576f09
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
+  KakaoSDKAuth: 45204252ff7c379c0f86c5573f97ec36885afca0
+  KakaoSDKCommon: 132164a6bac8bcd3a4346d3bf777f34f8f39fdca
+  KakaoSDKUser: 4c9cf1da78710d19d0b2c2dd32d1a44c544cdfa4
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   SwiftKeychainWrapper: 807ba1d63c33a7d0613288512399cd1eda1e470c
 
-PODFILE CHECKSUM: a8a7a5d0a7bae67a85d665695954546af261774c
+PODFILE CHECKSUM: 77bcc8131b0ba21db32c00ef3e079efa8ded014d
 
 COCOAPODS: 1.16.2

--- a/apps/web/ios/App/Podfile.lock
+++ b/apps/web/ios/App/Podfile.lock
@@ -1,5 +1,15 @@
 PODS:
   - Alamofire (5.9.1)
+  - AppAuth (2.0.0):
+    - AppAuth/Core (= 2.0.0)
+    - AppAuth/ExternalUserAgent (= 2.0.0)
+  - AppAuth/Core (2.0.0)
+  - AppAuth/ExternalUserAgent (2.0.0):
+    - AppAuth/Core
+  - AppCheckCore (11.2.0):
+    - GoogleUtilities/Environment (~> 8.0)
+    - GoogleUtilities/UserDefaults (~> 8.0)
+    - PromisesObjC (~> 2.4)
   - Capacitor (7.4.2):
     - CapacitorCordova
   - CapacitorApp (7.1.2):
@@ -40,6 +50,11 @@ PODS:
   - GoogleDataTransport (10.1.0):
     - nanopb (~> 3.30910.0)
     - PromisesObjC (~> 2.4)
+  - GoogleSignIn (9.1.0):
+    - AppAuth (~> 2.0)
+    - AppCheckCore (~> 11.0)
+    - GTMAppAuth (~> 5.0)
+    - GTMSessionFetcher/Core (~> 3.3)
   - GoogleUtilities/AppDelegateSwizzler (8.1.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
@@ -64,6 +79,10 @@ PODS:
   - GoogleUtilities/UserDefaults (8.1.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
+  - GTMAppAuth (5.0.0):
+    - AppAuth/Core (~> 2.0)
+    - GTMSessionFetcher/Core (< 4.0, >= 3.3)
+  - GTMSessionFetcher/Core (3.5.0)
   - KakaoSDKAuth (2.22.7):
     - KakaoSDKCommon (= 2.22.7)
   - KakaoSDKCommon (2.22.7):
@@ -91,19 +110,25 @@ DEPENDENCIES:
   - "CapacitorSecureStoragePlugin (from `../../../../node_modules/.pnpm/capacitor-secure-storage-plugin@0.12.0_@capacitor+core@7.4.2/node_modules/capacitor-secure-storage-plugin`)"
   - "CapacitorStatusBar (from `../../../../node_modules/.pnpm/@capacitor+status-bar@7.0.5_@capacitor+core@7.4.2/node_modules/@capacitor/status-bar`)"
   - Firebase/Messaging
+  - GoogleSignIn
   - KakaoSDKAuth
   - KakaoSDKUser
 
 SPEC REPOS:
   trunk:
     - Alamofire
+    - AppAuth
+    - AppCheckCore
     - Firebase
     - FirebaseCore
     - FirebaseCoreInternal
     - FirebaseInstallations
     - FirebaseMessaging
     - GoogleDataTransport
+    - GoogleSignIn
     - GoogleUtilities
+    - GTMAppAuth
+    - GTMSessionFetcher
     - KakaoSDKAuth
     - KakaoSDKCommon
     - KakaoSDKUser
@@ -127,6 +152,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Alamofire: f36a35757af4587d8e4f4bfa223ad10be2422b8c
+  AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
+  AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
   Capacitor: 9d9e481b79ffaeacaf7a85d6a11adec32bd33b59
   CapacitorApp: f01a913211780e0718dae9750442c3e23f96e106
   CapacitorCordova: 5e58d04631bc5094894ac106e2bf1da18a9e6151
@@ -139,7 +166,10 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 317270fec08a5d418fdbc8429282238cab3ac843
   FirebaseMessaging: 3b26e2cee503815e01c3701236b020aa9b576f09
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
+  GoogleSignIn: fcee2257188d5eda57a5e2b6a715550ffff9206d
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
+  GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
+  GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   KakaoSDKAuth: 45204252ff7c379c0f86c5573f97ec36885afca0
   KakaoSDKCommon: 132164a6bac8bcd3a4346d3bf777f34f8f39fdca
   KakaoSDKUser: 4c9cf1da78710d19d0b2c2dd32d1a44c544cdfa4
@@ -147,6 +177,6 @@ SPEC CHECKSUMS:
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   SwiftKeychainWrapper: 807ba1d63c33a7d0613288512399cd1eda1e470c
 
-PODFILE CHECKSUM: 77bcc8131b0ba21db32c00ef3e079efa8ded014d
+PODFILE CHECKSUM: 7afa462017b39fd288c7a02fecf885a2b15f2ca6
 
 COCOAPODS: 1.16.2

--- a/apps/web/src/_pages/auth/sign-in/SelectMethodPage.tsx
+++ b/apps/web/src/_pages/auth/sign-in/SelectMethodPage.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/features/auth';
 
 import { APPLE_SERVICE_ID, GOOGLE_CLIENT_ID } from '@/shared/storage';
+import { isAndroid } from '@/shared/utils';
 
 export const SelectMethodPage = () => {
   const router = useRouter();
@@ -50,11 +51,13 @@ export const SelectMethodPage = () => {
             redirectUri="/auth/sign-in/kakao"
           />
 
-          <AppleLoginButton
-            onClick={() => console.log('Apple login')}
-            serviceId={APPLE_SERVICE_ID}
-            redirectUri={'/auth/sign-in/apple/callback'}
-          />
+          {!isAndroid && (
+            <AppleLoginButton
+              onClick={() => console.log('Apple login')}
+              serviceId={APPLE_SERVICE_ID}
+              redirectUri={'/auth/sign-in/apple/callback'}
+            />
+          )}
 
           <GoogleLoginButton
             onClick={() => console.log('Google login')}

--- a/apps/web/src/entities/auth/model/types/types.ts
+++ b/apps/web/src/entities/auth/model/types/types.ts
@@ -38,6 +38,11 @@ export interface KakaoLoginRequestDto {
   code: string;
 }
 
+export interface KakaoNativeLoginRequestDto {
+  /** Native SDK에서 받은 카카오 액세스 토큰 */
+  accessToken: string;
+}
+
 /** SigninResponseDto와 동일한 구조를 공유하되, 추후 필드 확장을 위해 분리 */
 export interface KakaoLoginResponseDto {
   accessToken: string;
@@ -51,6 +56,11 @@ export interface AppleLoginRequestDto {
   code: string;
 }
 
+export interface AppleNativeLoginRequestDto {
+  /** Native SDK에서 받은 Apple 액세스 토큰 */
+  accessToken: string;
+}
+
 /** SigninResponseDto와 동일한 구조를 공유하되, 추후 필드 확장을 위해 분리 */
 export interface AppleLoginResponseDto {
   accessToken: string;
@@ -62,6 +72,11 @@ export interface AppleLoginResponseDto {
 export interface GoogleLoginRequestDto {
   /** Google OAuth 인가 코드 */
   code: string;
+}
+
+export interface GoogleNativeLoginRequestDto {
+  /** Native SDK에서 받은 Google 액세스 토큰 */
+  accessToken: string;
 }
 
 /** SigninResponseDto와 동일한 구조를 공유하되, 추후 필드 확장을 위해 분리 */

--- a/apps/web/src/features/auth/api/post/session.ts
+++ b/apps/web/src/features/auth/api/post/session.ts
@@ -7,10 +7,13 @@ import type {
   SignoutRequestDto,
   KakaoLoginRequestDto,
   KakaoLoginResponseDto,
+  KakaoNativeLoginRequestDto,
   AppleLoginRequestDto,
   AppleLoginResponseDto,
+  AppleNativeLoginRequestDto,
   GoogleLoginRequestDto,
   GoogleLoginResponseDto,
+  GoogleNativeLoginRequestDto,
 } from '@/entities/auth';
 
 import { API } from '@/shared/api';
@@ -51,6 +54,27 @@ export const kakaoLogin = async (
 };
 
 /**
+ * 모바일 Native SDK에서 받은 카카오 액세스 토큰을 서버로 전달해 로그인 처리.
+ *
+ * TODO: 실제 API 엔드포인트로 교체 필요
+ * return API.post<KakaoLoginResponseDto>(`${URL_PREFIX}/oauth/kakao/native`, data);
+ */
+export const kakaoNativeLogin = async (
+  data: KakaoNativeLoginRequestDto,
+): Promise<KakaoLoginResponseDto> => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({
+        accessToken: `mock_access_token_for_native_${data.accessToken.slice(0, 8)}`,
+        name: '테스트 유저',
+        email: 'test@causw.ac.kr',
+        profileImgUrl: '',
+      });
+    }, 1500);
+  });
+};
+
+/**
  * Apple OAuth 인가 코드를 서버로 전달해 로그인 처리.
  *
  * TODO: 실제 API 엔드포인트로 교체 필요
@@ -72,6 +96,27 @@ export const appleLogin = async (
 };
 
 /**
+ * 모바일 Native SDK에서 받은 Apple 액세스 토큰을 서버로 전달해 로그인 처리.
+ *
+ * TODO: 실제 API 엔드포인트로 교체 필요
+ * return API.post<AppleLoginResponseDto>(`${URL_PREFIX}/oauth/apple/native`, data);
+ */
+export const appleNativeLogin = async (
+  data: AppleNativeLoginRequestDto,
+): Promise<AppleLoginResponseDto> => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({
+        accessToken: `mock_access_token_for_native_${data.accessToken.slice(0, 8)}`,
+        name: '테스트 유저',
+        email: 'test@causw.ac.kr',
+        profileImgUrl: '',
+      });
+    }, 1500);
+  });
+};
+
+/**
  * Google OAuth 인가 코드를 서버로 전달해 로그인 처리.
  *
  * TODO: 실제 API 엔드포인트로 교체 필요
@@ -84,6 +129,27 @@ export const googleLogin = async (
     setTimeout(() => {
       resolve({
         accessToken: `mock_access_token_for_code_${data.code.slice(0, 8)}`,
+        name: '테스트 유저',
+        email: 'test@causw.ac.kr',
+        profileImgUrl: '',
+      });
+    }, 1500);
+  });
+};
+
+/**
+ * 모바일 Native SDK에서 받은 Google 액세스 토큰을 서버로 전달해 로그인 처리.
+ *
+ * TODO: 실제 API 엔드포인트로 교체 필요
+ * return API.post<GoogleLoginResponseDto>(`${URL_PREFIX}/oauth/google/native`, data);
+ */
+export const googleNativeLogin = async (
+  data: GoogleNativeLoginRequestDto,
+): Promise<GoogleLoginResponseDto> => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({
+        accessToken: `mock_access_token_for_native_${data.accessToken.slice(0, 8)}`,
         name: '테스트 유저',
         email: 'test@causw.ac.kr',
         profileImgUrl: '',

--- a/apps/web/src/features/auth/ui/apple-login-button/AppleLoginButton.tsx
+++ b/apps/web/src/features/auth/ui/apple-login-button/AppleLoginButton.tsx
@@ -8,9 +8,9 @@ import { AppleLogo, Flex, mergeStyles } from '@causw/cds';
 
 import { appleNativeLogin } from '@/features/auth/api';
 
+import { requestNativeSocialLogin } from '@/shared/lib/capacitor';
 import { toast } from '@/shared/model';
 import { extractErrorMessage, isMobile } from '@/shared/utils';
-import { requestNativeSocialLogin } from '@/shared/utils/auth';
 
 type AppleLoginButtonProps = ComponentProps<'button'> & {
   serviceId?: string;
@@ -44,7 +44,10 @@ export const AppleLoginButton = ({
         } catch (error) {
           toast.dismiss(loadingToastId);
           toast.error(
-            extractErrorMessage(error, '소셜 로그인에 실패했습니다. 다시 시도해 주세요.'),
+            extractErrorMessage(
+              error,
+              '소셜 로그인에 실패했습니다. 다시 시도해 주세요.',
+            ),
           );
           router.replace('/auth/sign-in');
         }

--- a/apps/web/src/features/auth/ui/apple-login-button/AppleLoginButton.tsx
+++ b/apps/web/src/features/auth/ui/apple-login-button/AppleLoginButton.tsx
@@ -1,6 +1,16 @@
+'use client';
+
 import type { ComponentProps } from 'react';
 
+import { useRouter } from 'next/navigation';
+
 import { AppleLogo, Flex, mergeStyles } from '@causw/cds';
+
+import { appleNativeLogin } from '@/features/auth/api';
+
+import { toast } from '@/shared/model';
+import { extractErrorMessage, isMobile } from '@/shared/utils';
+import { requestNativeSocialLogin } from '@/shared/utils/auth';
 
 type AppleLoginButtonProps = ComponentProps<'button'> & {
   serviceId?: string;
@@ -16,8 +26,33 @@ export const AppleLoginButton = ({
   state,
   ...props
 }: AppleLoginButtonProps) => {
+  const router = useRouter();
+
   const handleLogin: React.MouseEventHandler<HTMLButtonElement> = (e) => {
     onClick?.(e);
+
+    if (e.defaultPrevented) return;
+    if (isMobile) {
+      const handleMobileLogin = async () => {
+        const loadingToastId = String(toast.loading('apple 로그인 중...'));
+        try {
+          const nativeAccessToken = await requestNativeSocialLogin('apple');
+          await appleNativeLogin({ accessToken: nativeAccessToken });
+          toast.dismiss(loadingToastId);
+          toast.success('로그인되었습니다.');
+          router.replace('/home');
+        } catch (error) {
+          toast.dismiss(loadingToastId);
+          toast.error(
+            extractErrorMessage(error, '소셜 로그인에 실패했습니다. 다시 시도해 주세요.'),
+          );
+          router.replace('/auth/sign-in');
+        }
+      };
+
+      handleMobileLogin();
+      return;
+    }
 
     if (!serviceId || !redirectUri) return;
 

--- a/apps/web/src/features/auth/ui/google-login-button/GoogleLoginButton.tsx
+++ b/apps/web/src/features/auth/ui/google-login-button/GoogleLoginButton.tsx
@@ -8,9 +8,9 @@ import { Flex, GoogleLogo, mergeStyles } from '@causw/cds';
 
 import { googleNativeLogin } from '@/features/auth/api';
 
+import { requestNativeSocialLogin } from '@/shared/lib/capacitor';
 import { toast } from '@/shared/model';
 import { extractErrorMessage, isMobile } from '@/shared/utils';
-import { requestNativeSocialLogin } from '@/shared/utils/auth';
 
 type GoogleLoginButtonProps = ComponentProps<'button'> & {
   clientId?: string;
@@ -46,7 +46,10 @@ export const GoogleLoginButton = ({
         } catch (error) {
           toast.dismiss(loadingToastId);
           toast.error(
-            extractErrorMessage(error, '소셜 로그인에 실패했습니다. 다시 시도해 주세요.'),
+            extractErrorMessage(
+              error,
+              '소셜 로그인에 실패했습니다. 다시 시도해 주세요.',
+            ),
           );
           router.replace('/auth/sign-in');
         }

--- a/apps/web/src/features/auth/ui/google-login-button/GoogleLoginButton.tsx
+++ b/apps/web/src/features/auth/ui/google-login-button/GoogleLoginButton.tsx
@@ -1,6 +1,16 @@
+'use client';
+
 import type { ComponentProps } from 'react';
 
+import { useRouter } from 'next/navigation';
+
 import { Flex, GoogleLogo, mergeStyles } from '@causw/cds';
+
+import { googleNativeLogin } from '@/features/auth/api';
+
+import { toast } from '@/shared/model';
+import { extractErrorMessage, isMobile } from '@/shared/utils';
+import { requestNativeSocialLogin } from '@/shared/utils/auth';
 
 type GoogleLoginButtonProps = ComponentProps<'button'> & {
   clientId?: string;
@@ -18,8 +28,33 @@ export const GoogleLoginButton = ({
   scope = 'openid email profile',
   ...props
 }: GoogleLoginButtonProps) => {
+  const router = useRouter();
+
   const handleLogin: React.MouseEventHandler<HTMLButtonElement> = (e) => {
     onClick?.(e);
+
+    if (e.defaultPrevented) return;
+    if (isMobile) {
+      const handleMobileLogin = async () => {
+        const loadingToastId = String(toast.loading('google 로그인 중...'));
+        try {
+          const nativeAccessToken = await requestNativeSocialLogin('google');
+          await googleNativeLogin({ accessToken: nativeAccessToken });
+          toast.dismiss(loadingToastId);
+          toast.success('로그인되었습니다.');
+          router.replace('/home');
+        } catch (error) {
+          toast.dismiss(loadingToastId);
+          toast.error(
+            extractErrorMessage(error, '소셜 로그인에 실패했습니다. 다시 시도해 주세요.'),
+          );
+          router.replace('/auth/sign-in');
+        }
+      };
+
+      handleMobileLogin();
+      return;
+    }
 
     if (!clientId || !redirectUri) return;
 

--- a/apps/web/src/features/auth/ui/kakao-login-button/KakaoLoginButton.tsx
+++ b/apps/web/src/features/auth/ui/kakao-login-button/KakaoLoginButton.tsx
@@ -8,9 +8,9 @@ import { Flex, KakaoTalkBlackLogo, mergeStyles } from '@causw/cds';
 
 import { kakaoNativeLogin } from '@/features/auth/api';
 
+import { requestNativeSocialLogin } from '@/shared/lib/capacitor';
 import { toast } from '@/shared/model';
 import { extractErrorMessage, isMobile } from '@/shared/utils';
-import { requestNativeSocialLogin } from '@/shared/utils/auth';
 
 import { useKakaoSDK } from '../../lib/useKakaoSDK';
 
@@ -51,7 +51,10 @@ export const KakaoLoginButton = ({
         } catch (error) {
           toast.dismiss(loadingToastId);
           toast.error(
-            extractErrorMessage(error, '소셜 로그인에 실패했습니다. 다시 시도해 주세요.'),
+            extractErrorMessage(
+              error,
+              '소셜 로그인에 실패했습니다. 다시 시도해 주세요.',
+            ),
           );
           router.replace('/auth/sign-in');
         }

--- a/apps/web/src/features/auth/ui/kakao-login-button/KakaoLoginButton.tsx
+++ b/apps/web/src/features/auth/ui/kakao-login-button/KakaoLoginButton.tsx
@@ -2,7 +2,15 @@
 
 import type { ComponentProps } from 'react';
 
+import { useRouter } from 'next/navigation';
+
 import { Flex, KakaoTalkBlackLogo, mergeStyles } from '@causw/cds';
+
+import { kakaoNativeLogin } from '@/features/auth/api';
+
+import { toast } from '@/shared/model';
+import { extractErrorMessage, isMobile } from '@/shared/utils';
+import { requestNativeSocialLogin } from '@/shared/utils/auth';
 
 import { useKakaoSDK } from '../../lib/useKakaoSDK';
 
@@ -25,9 +33,33 @@ export const KakaoLoginButton = ({
   ...props
 }: KakaoLoginButtonProps) => {
   const { isReady } = useKakaoSDK();
+  const router = useRouter();
 
   const handleLogin: React.MouseEventHandler<HTMLButtonElement> = (e) => {
     onClick?.(e);
+
+    if (e.defaultPrevented) return;
+    if (isMobile) {
+      const handleMobileLogin = async () => {
+        const loadingToastId = String(toast.loading('kakao 로그인 중...'));
+        try {
+          const nativeAccessToken = await requestNativeSocialLogin('kakao');
+          await kakaoNativeLogin({ accessToken: nativeAccessToken });
+          toast.dismiss(loadingToastId);
+          toast.success('로그인되었습니다.');
+          router.replace('/home');
+        } catch (error) {
+          toast.dismiss(loadingToastId);
+          toast.error(
+            extractErrorMessage(error, '소셜 로그인에 실패했습니다. 다시 시도해 주세요.'),
+          );
+          router.replace('/auth/sign-in');
+        }
+      };
+
+      handleMobileLogin();
+      return;
+    }
 
     if (!isReady || !window.Kakao?.Auth) return;
 

--- a/apps/web/src/shared/lib/capacitor/auth/index.ts
+++ b/apps/web/src/shared/lib/capacitor/auth/index.ts
@@ -1,0 +1,2 @@
+export { requestNativeSocialLogin } from './nativeSocialBridge';
+export type { SocialProvider } from './nativeSocialBridge';

--- a/apps/web/src/shared/lib/capacitor/auth/nativeSocialBridge.ts
+++ b/apps/web/src/shared/lib/capacitor/auth/nativeSocialBridge.ts
@@ -1,4 +1,4 @@
-import { isMobile } from '@/shared/utils';
+import { isAndroid, isMobile } from '@/shared/utils';
 
 export type SocialProvider = 'kakao' | 'apple' | 'google';
 
@@ -105,6 +105,14 @@ const normalizeErrorMessage = (payload: NativeSocialLoginResult) => {
     return '현재 기기에서는 Apple 로그인을 사용할 수 없습니다.';
   }
 
+  if (errorCode === 'APPLE_LOGIN_UNSUPPORTED') {
+    return '현재 기기에서는 Apple 로그인을 사용할 수 없습니다.';
+  }
+
+  if (errorCode === 'KAKAO_LOGIN_ACCOUNT_REQUIRED') {
+    return '카카오톡 계정이 연결되어 있지 않습니다. 카카오 계정으로 로그인해 주세요.';
+  }
+
   if (
     errorCode === 'KAKAO_LOGIN_FAILED' ||
     errorCode === 'GOOGLE_LOGIN_FAILED' ||
@@ -188,6 +196,13 @@ const sendToNativeBridge = (payload: NativeSocialLoginRequest): boolean => {
   return false;
 };
 
+const validateProvider = (provider: SocialProvider) => {
+  if (provider === 'apple' && isAndroid) {
+    return '현재 기기에서는 Apple 로그인을 사용할 수 없습니다.';
+  }
+  return null;
+};
+
 export const requestNativeSocialLogin = (
   provider: SocialProvider,
   timeoutMs = DEFAULT_TIMEOUT_MS,
@@ -195,6 +210,12 @@ export const requestNativeSocialLogin = (
   new Promise<string>((resolve, reject) => {
     if (!isMobile) {
       reject(new Error('모바일 환경에서만 소셜 로그인을 사용할 수 있습니다.'));
+      return;
+    }
+
+    const validationError = validateProvider(provider);
+    if (validationError) {
+      reject(new Error(validationError));
       return;
     }
 

--- a/apps/web/src/shared/lib/capacitor/index.ts
+++ b/apps/web/src/shared/lib/capacitor/index.ts
@@ -1,1 +1,2 @@
 export * from './push-notification';
+export * from './auth';

--- a/apps/web/src/shared/utils/auth/index.ts
+++ b/apps/web/src/shared/utils/auth/index.ts
@@ -1,1 +1,3 @@
 export { isPublicEndpoint } from './isPublicEndpoint';
+export { requestNativeSocialLogin } from './nativeSocialBridge';
+export type { SocialProvider } from './nativeSocialBridge';

--- a/apps/web/src/shared/utils/auth/index.ts
+++ b/apps/web/src/shared/utils/auth/index.ts
@@ -1,3 +1,1 @@
 export { isPublicEndpoint } from './isPublicEndpoint';
-export { requestNativeSocialLogin } from './nativeSocialBridge';
-export type { SocialProvider } from './nativeSocialBridge';

--- a/apps/web/src/shared/utils/auth/nativeSocialBridge.ts
+++ b/apps/web/src/shared/utils/auth/nativeSocialBridge.ts
@@ -1,0 +1,160 @@
+import { isMobile } from '@/shared/utils';
+
+export type SocialProvider = 'kakao' | 'apple' | 'google';
+
+type NativeSocialLoginRequest = {
+  provider: SocialProvider;
+  requestId: string;
+};
+
+type NativeSocialLoginResult = {
+  provider: SocialProvider;
+  requestId: string;
+  accessToken?: string;
+  errorCode?: string;
+  message?: string;
+};
+
+type PendingRequest = {
+  provider: SocialProvider;
+  resolve: (value: string) => void;
+  reject: (reason?: unknown) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const pendingRequests = new Map<string, PendingRequest>();
+let isBridgeHandlerInitialized = false;
+
+declare global {
+  interface Window {
+    __CAUSW_ON_NATIVE_SOCIAL_LOGIN__?: (
+      payload: NativeSocialLoginResult,
+    ) => void;
+    webkit?: {
+      messageHandlers?: Record<
+        string,
+        { postMessage: (payload: unknown) => void }
+      >;
+    };
+    CauswSocialLoginBridge?: {
+      requestSocialLogin?: (payload: string) => void;
+    };
+    AndroidSocialLogin?: {
+      requestSocialLogin?: (payload: string) => void;
+    };
+    NativeBridge?: {
+      requestSocialLogin?: (payload: NativeSocialLoginRequest) => void;
+    };
+  }
+}
+
+const createRequestId = () =>
+  `social_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+
+const normalizeErrorMessage = (payload: NativeSocialLoginResult) => {
+  if (payload.message) return payload.message;
+  if (payload.errorCode)
+    return `Native social login failed: ${payload.errorCode}`;
+  return 'Native social login failed';
+};
+
+const resolveFromPayload = (payload: NativeSocialLoginResult) => {
+  const pending = pendingRequests.get(payload.requestId);
+  if (!pending) return;
+
+  clearTimeout(pending.timer);
+  pendingRequests.delete(payload.requestId);
+
+  if (payload.provider !== pending.provider) {
+    pending.reject(new Error('Social login provider mismatch.'));
+    return;
+  }
+
+  if (!payload.accessToken) {
+    pending.reject(new Error(normalizeErrorMessage(payload)));
+    return;
+  }
+
+  pending.resolve(payload.accessToken);
+};
+
+const initializeBridgeHandler = () => {
+  if (isBridgeHandlerInitialized || typeof window === 'undefined') return;
+
+  window.__CAUSW_ON_NATIVE_SOCIAL_LOGIN__ = (payload) => {
+    resolveFromPayload(payload);
+  };
+
+  window.addEventListener('causw:social-login-result', (event: Event) => {
+    const customEvent = event as CustomEvent<NativeSocialLoginResult>;
+    if (!customEvent.detail) return;
+    resolveFromPayload(customEvent.detail);
+  });
+
+  isBridgeHandlerInitialized = true;
+};
+
+const sendToNativeBridge = (payload: NativeSocialLoginRequest): boolean => {
+  if (typeof window === 'undefined') return false;
+
+  const iosHandler =
+    window.webkit?.messageHandlers?.causwSocialLogin ??
+    window.webkit?.messageHandlers?.socialLogin;
+  if (iosHandler) {
+    iosHandler.postMessage(payload);
+    return true;
+  }
+
+  if (window.CauswSocialLoginBridge?.requestSocialLogin) {
+    window.CauswSocialLoginBridge.requestSocialLogin(JSON.stringify(payload));
+    return true;
+  }
+
+  if (window.AndroidSocialLogin?.requestSocialLogin) {
+    window.AndroidSocialLogin.requestSocialLogin(JSON.stringify(payload));
+    return true;
+  }
+
+  if (window.NativeBridge?.requestSocialLogin) {
+    window.NativeBridge.requestSocialLogin(payload);
+    return true;
+  }
+
+  return false;
+};
+
+export const requestNativeSocialLogin = (
+  provider: SocialProvider,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+) =>
+  new Promise<string>((resolve, reject) => {
+    if (!isMobile) {
+      reject(new Error('Native social login is only available on mobile.'));
+      return;
+    }
+
+    initializeBridgeHandler();
+
+    const requestId = createRequestId();
+    const payload: NativeSocialLoginRequest = { provider, requestId };
+
+    const timer = setTimeout(() => {
+      pendingRequests.delete(requestId);
+      reject(new Error('Native social login request timed out.'));
+    }, timeoutMs);
+
+    pendingRequests.set(requestId, {
+      provider,
+      resolve,
+      reject,
+      timer,
+    });
+
+    const sent = sendToNativeBridge(payload);
+    if (!sent) {
+      clearTimeout(timer);
+      pendingRequests.delete(requestId);
+      reject(new Error('Native social bridge is not available.'));
+    }
+  });

--- a/apps/web/src/shared/utils/auth/nativeSocialBridge.ts
+++ b/apps/web/src/shared/utils/auth/nativeSocialBridge.ts
@@ -53,10 +53,74 @@ const createRequestId = () =>
   `social_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
 
 const normalizeErrorMessage = (payload: NativeSocialLoginResult) => {
-  if (payload.message) return payload.message;
-  if (payload.errorCode)
-    return `Native social login failed: ${payload.errorCode}`;
-  return 'Native social login failed';
+  const errorCode = payload.errorCode ?? '';
+  const rawMessage = payload.message ?? '';
+  const normalized = `${errorCode} ${rawMessage}`.toLowerCase();
+
+  if (
+    normalized.includes('cancel') ||
+    normalized.includes('canceled') ||
+    normalized.includes('cancelled') ||
+    normalized.includes('user_cancel') ||
+    normalized.includes('user canceled') ||
+    normalized.includes('사용자 취소') ||
+    normalized.includes('취소')
+  ) {
+    return '로그인이 취소되었습니다.';
+  }
+
+  if (normalized.includes('10:') || normalized.includes('developer_error')) {
+    return '구글 로그인 설정이 올바르지 않습니다. 잠시 후 다시 시도해 주세요.';
+  }
+
+  if (normalized.includes('timeout')) {
+    return '로그인 시간이 초과되었습니다. 다시 시도해 주세요.';
+  }
+
+  if (
+    normalized.includes('network') ||
+    normalized.includes('offline') ||
+    normalized.includes('connection')
+  ) {
+    return '네트워크 연결이 불안정합니다. 다시 시도해 주세요.';
+  }
+
+  if (errorCode === 'UNSUPPORTED_PROVIDER') {
+    return '지원하지 않는 로그인 방식입니다.';
+  }
+
+  if (errorCode === 'INVALID_PAYLOAD') {
+    return '로그인 요청 형식이 올바르지 않습니다. 다시 시도해 주세요.';
+  }
+
+  if (errorCode === 'GOOGLE_CLIENT_ID_MISSING') {
+    return '구글 로그인 설정값이 누락되었습니다. 관리자에게 문의해 주세요.';
+  }
+
+  if (errorCode === 'PRESENTING_VIEW_CONTROLLER_MISSING') {
+    return '로그인 화면을 표시할 수 없습니다. 앱을 다시 실행해 주세요.';
+  }
+
+  if (errorCode === 'APPLE_LOGIN_UNAVAILABLE') {
+    return '현재 기기에서는 Apple 로그인을 사용할 수 없습니다.';
+  }
+
+  if (
+    errorCode === 'KAKAO_LOGIN_FAILED' ||
+    errorCode === 'GOOGLE_LOGIN_FAILED' ||
+    errorCode === 'APPLE_LOGIN_FAILED'
+  ) {
+    return '소셜 로그인에 실패했습니다. 다시 시도해 주세요.';
+  }
+
+  if (
+    errorCode === 'EMPTY_ACCESS_TOKEN' ||
+    errorCode === 'APPLE_CREDENTIAL_MISSING'
+  ) {
+    return '로그인 정보를 가져오지 못했습니다. 다시 시도해 주세요.';
+  }
+
+  return '소셜 로그인에 실패했습니다. 다시 시도해 주세요.';
 };
 
 const resolveFromPayload = (payload: NativeSocialLoginResult) => {
@@ -130,7 +194,7 @@ export const requestNativeSocialLogin = (
 ) =>
   new Promise<string>((resolve, reject) => {
     if (!isMobile) {
-      reject(new Error('Native social login is only available on mobile.'));
+      reject(new Error('모바일 환경에서만 소셜 로그인을 사용할 수 있습니다.'));
       return;
     }
 
@@ -141,7 +205,7 @@ export const requestNativeSocialLogin = (
 
     const timer = setTimeout(() => {
       pendingRequests.delete(requestId);
-      reject(new Error('Native social login request timed out.'));
+      reject(new Error('로그인 시간이 초과되었습니다. 다시 시도해 주세요.'));
     }, timeoutMs);
 
     pendingRequests.set(requestId, {
@@ -155,6 +219,8 @@ export const requestNativeSocialLogin = (
     if (!sent) {
       clearTimeout(timer);
       pendingRequests.delete(requestId);
-      reject(new Error('Native social bridge is not available.'));
+      reject(
+        new Error('앱 로그인 연결에 실패했습니다. 앱을 다시 실행해 주세요.'),
+      );
     }
   });


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #94 #95 


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- ios, android 환경에서의 소셜 로그인 구현


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- native bridge 로직 ios, android에 추가
- native bridge 로직 shared/utils에 추가 
- 안드로이드 환경 구글 로그인, 카카오톡 로그인 연동
- ios 환경 구글 로그인, 카카오톡 로그인, 애플 로그인 연동
- safe-area 이슈 핸들링


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- 현재 소셜 로그인 sdk 열고 닫으면서 화면이 깨지는 이슈가 있는데, 소셜 로그인과는 무관한 safe-area 이슈라서 따로 파서 핸들링할 예정입니다
- api 연동은 되어있지 않은 상황이라 sdk의 정상 동작 여부만 봐주시면 좋을 것 같습니다.


## 🧪 Test & Verification

https://github.com/user-attachments/assets/90de76b3-9dd2-411e-8237-74662f4521b4
https://github.com/user-attachments/assets/8b831a79-7bec-43f3-816f-a7cbd74d460d

https://github.com/user-attachments/assets/e64d21df-fc82-48bb-86d1-219247cb31ec




> 테스트 결과나 캡처가 있다면 첨부해주세요.


## 📎 Additional Notes
-
