### PR TITLE
[FEAT/#119] 개인정보-알림 설정 페이지 api 연동

### DIFF
--- a/apps/web/src/_pages/setting/notifications/SettingNotificationsPage.tsx
+++ b/apps/web/src/_pages/setting/notifications/SettingNotificationsPage.tsx
@@ -10,7 +10,12 @@ import {
 } from '@/widgets/setting';
 import { SETTING_NOTIFICATIONS } from '@/widgets/setting/config';
 
-import { useNotificationSettings } from '@/entities/notification';
+import { useNotificationSettingsOptimisticMutations } from '@/features/notification';
+
+import {
+  type CommunityNotificationSettings,
+  useNotificationSettings,
+} from '@/entities/notification';
 
 import { ActionHeader, HydrationSuspense, SuspenseView } from '@/shared/ui';
 import { QueryErrorBoundary } from '@/shared/ui/provider';
@@ -27,6 +32,12 @@ export const SettingNotificationsPage = () => {
 
 const SettingNotificationContent = () => {
   const { data: settings } = useNotificationSettings();
+  const {
+    updateNotificationSettings,
+    updateOfficialBoardNotification,
+    isUpdatingNotificationSettings,
+    isUpdatingOfficialBoards,
+  } = useNotificationSettingsOptimisticMutations();
 
   return (
     <VStack gap="sm" className="w-full">
@@ -37,10 +48,45 @@ const SettingNotificationContent = () => {
       <VStack gap="md" className="w-full px-4">
         <Text typography="title-22-bold">{SETTING_NOTIFICATIONS.title}</Text>
 
-        <CommunityNotificationSection settings={settings.community} />
-        <OfficialAccountNotificationSection boards={settings.officialBoards} />
-        <NoticeNotificationSection settings={settings.service} />
-        <EventNotificationSection settings={settings.ceremony} />
+        <CommunityNotificationSection
+          settings={settings.community}
+          onToggle={(key, checked) => {
+            if (isUpdatingNotificationSettings) return;
+
+            const community = {
+              [key]: checked,
+            } as Partial<CommunityNotificationSettings>;
+
+            updateNotificationSettings({ community });
+          }}
+        />
+        <OfficialAccountNotificationSection
+          boards={settings.officialBoards}
+          onToggle={(boardId, subscribed) => {
+            if (isUpdatingOfficialBoards) return;
+            updateOfficialBoardNotification({ boardId, subscribed });
+          }}
+        />
+        <NoticeNotificationSection
+          settings={settings.service}
+          onToggle={(checked) => {
+            if (isUpdatingNotificationSettings) return;
+
+            updateNotificationSettings({
+              service: { noticeEnabled: checked },
+            });
+          }}
+        />
+        <EventNotificationSection
+          settings={settings.ceremony}
+          onToggle={(checked) => {
+            if (isUpdatingNotificationSettings) return;
+
+            updateNotificationSettings({
+              ceremony: { enabled: checked },
+            });
+          }}
+        />
       </VStack>
     </VStack>
   );

--- a/apps/web/src/_pages/setting/notifications/SettingNotificationsPage.tsx
+++ b/apps/web/src/_pages/setting/notifications/SettingNotificationsPage.tsx
@@ -26,11 +26,17 @@ import {
 
 export const SettingNotificationsPage = () => {
   return (
-    <QueryErrorBoundary fallbackMessage="알림 설정 데이터를 불러오지 못했어요.">
-      <HydrationSuspense fallback={<SuspenseView />}>
-        <SettingNotificationContent />
-      </HydrationSuspense>
-    </QueryErrorBoundary>
+    <VStack gap="sm" className="w-full">
+      <ActionHeader>
+        <ActionHeader.BackButton>뒤로</ActionHeader.BackButton>
+      </ActionHeader>
+
+      <QueryErrorBoundary fallbackMessage="알림 설정 데이터를 불러오지 못했어요.">
+        <HydrationSuspense fallback={<SuspenseView />}>
+          <SettingNotificationContent />
+        </HydrationSuspense>
+      </QueryErrorBoundary>
+    </VStack>
   );
 };
 
@@ -44,54 +50,48 @@ const SettingNotificationContent = () => {
   } = useNotificationSettingsOptimisticMutations();
 
   return (
-    <VStack gap="sm" className="w-full">
-      <ActionHeader>
-        <ActionHeader.BackButton>뒤로</ActionHeader.BackButton>
-      </ActionHeader>
+    <VStack gap="md" className="w-full px-4">
+      <Text typography="title-22-bold">{SETTING_NOTIFICATIONS.title}</Text>
 
-      <VStack gap="md" className="w-full px-4">
-        <Text typography="title-22-bold">{SETTING_NOTIFICATIONS.title}</Text>
+      <CommunityNotificationSection
+        settings={settings.community}
+        onToggle={(key, checked) => {
+          if (isUpdatingNotificationSettings) return;
 
-        <CommunityNotificationSection
-          settings={settings.community}
-          onToggle={(key, checked) => {
-            if (isUpdatingNotificationSettings) return;
+          const community = {
+            [key]: checked,
+          } as Partial<CommunityNotificationSettings>;
 
-            const community = {
-              [key]: checked,
-            } as Partial<CommunityNotificationSettings>;
+          updateNotificationSettings({ community });
+        }}
+      />
+      <OfficialAccountNotificationSection
+        boards={settings.officialBoards}
+        onToggle={(boardId, subscribed) => {
+          if (isUpdatingOfficialBoards) return;
+          updateOfficialBoardNotification({ boardId, subscribed });
+        }}
+      />
+      <NoticeNotificationSection
+        settings={settings.service}
+        onToggle={(checked) => {
+          if (isUpdatingNotificationSettings) return;
 
-            updateNotificationSettings({ community });
-          }}
-        />
-        <OfficialAccountNotificationSection
-          boards={settings.officialBoards}
-          onToggle={(boardId, subscribed) => {
-            if (isUpdatingOfficialBoards) return;
-            updateOfficialBoardNotification({ boardId, subscribed });
-          }}
-        />
-        <NoticeNotificationSection
-          settings={settings.service}
-          onToggle={(checked) => {
-            if (isUpdatingNotificationSettings) return;
+          updateNotificationSettings({
+            service: { noticeEnabled: checked },
+          });
+        }}
+      />
+      <EventNotificationSection
+        settings={settings.ceremony}
+        onToggle={(checked) => {
+          if (isUpdatingNotificationSettings) return;
 
-            updateNotificationSettings({
-              service: { noticeEnabled: checked },
-            });
-          }}
-        />
-        <EventNotificationSection
-          settings={settings.ceremony}
-          onToggle={(checked) => {
-            if (isUpdatingNotificationSettings) return;
-
-            updateNotificationSettings({
-              ceremony: { enabled: checked },
-            });
-          }}
-        />
-      </VStack>
+          updateNotificationSettings({
+            ceremony: { enabled: checked },
+          });
+        }}
+      />
     </VStack>
   );
 };

--- a/apps/web/src/_pages/setting/notifications/SettingNotificationsPage.tsx
+++ b/apps/web/src/_pages/setting/notifications/SettingNotificationsPage.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+
 import { Text, VStack } from '@causw/cds';
 
 import {
@@ -7,6 +9,7 @@ import {
   EventNotificationSection,
   NoticeNotificationSection,
   OfficialAccountNotificationSection,
+  PushNotificationPermissionNotice,
 } from '@/widgets/setting';
 import { SETTING_NOTIFICATIONS } from '@/widgets/setting/config';
 
@@ -17,6 +20,7 @@ import {
   useNotificationSettings,
 } from '@/entities/notification';
 
+import { isPushNotificationPermissionDenied } from '@/shared/lib';
 import {
   ActionHeader,
   HydrationSuspense,
@@ -49,10 +53,29 @@ const SettingNotificationContent = () => {
     isUpdatingOfficialBoards,
   } = useNotificationSettingsOptimisticMutations();
 
+  const [isPushNotificationDenied, setIsPushNotificationDenied] =
+    useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const syncPushNotificationPermission = async () => {
+      const denied = await isPushNotificationPermissionDenied();
+      if (!mounted) return;
+      setIsPushNotificationDenied(denied);
+    };
+
+    void syncPushNotificationPermission();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
   return (
     <VStack gap="md" className="w-full px-4">
       <Text typography="title-22-bold">{SETTING_NOTIFICATIONS.title}</Text>
-
+      {isPushNotificationDenied && <PushNotificationPermissionNotice />}
       <CommunityNotificationSection
         settings={settings.community}
         onToggle={(key, checked) => {

--- a/apps/web/src/_pages/setting/notifications/SettingNotificationsPage.tsx
+++ b/apps/web/src/_pages/setting/notifications/SettingNotificationsPage.tsx
@@ -10,9 +10,24 @@ import {
 } from '@/widgets/setting';
 import { SETTING_NOTIFICATIONS } from '@/widgets/setting/config';
 
-import { ActionHeader } from '@/shared/ui';
+import { useNotificationSettings } from '@/entities/notification';
+
+import { ActionHeader, HydrationSuspense, SuspenseView } from '@/shared/ui';
+import { QueryErrorBoundary } from '@/shared/ui/provider';
 
 export const SettingNotificationsPage = () => {
+  return (
+    <QueryErrorBoundary fallbackMessage="알림 설정 데이터를 불러오지 못했어요.">
+      <HydrationSuspense fallback={<SuspenseView />}>
+        <SettingNotificationContent />
+      </HydrationSuspense>
+    </QueryErrorBoundary>
+  );
+};
+
+const SettingNotificationContent = () => {
+  const { data: settings } = useNotificationSettings();
+
   return (
     <VStack gap="sm" className="w-full">
       <ActionHeader>
@@ -22,10 +37,10 @@ export const SettingNotificationsPage = () => {
       <VStack gap="md" className="w-full px-4">
         <Text typography="title-22-bold">{SETTING_NOTIFICATIONS.title}</Text>
 
-        <CommunityNotificationSection />
-        <OfficialAccountNotificationSection />
-        <NoticeNotificationSection />
-        <EventNotificationSection />
+        <CommunityNotificationSection settings={settings.community} />
+        <OfficialAccountNotificationSection boards={settings.officialBoards} />
+        <NoticeNotificationSection settings={settings.service} />
+        <EventNotificationSection settings={settings.ceremony} />
       </VStack>
     </VStack>
   );

--- a/apps/web/src/_pages/setting/notifications/SettingNotificationsPage.tsx
+++ b/apps/web/src/_pages/setting/notifications/SettingNotificationsPage.tsx
@@ -17,8 +17,12 @@ import {
   useNotificationSettings,
 } from '@/entities/notification';
 
-import { ActionHeader, HydrationSuspense, SuspenseView } from '@/shared/ui';
-import { QueryErrorBoundary } from '@/shared/ui/provider';
+import {
+  ActionHeader,
+  HydrationSuspense,
+  QueryErrorBoundary,
+  SuspenseView,
+} from '@/shared/ui';
 
 export const SettingNotificationsPage = () => {
   return (

--- a/apps/web/src/app/(causw)/setting/layout.tsx
+++ b/apps/web/src/app/(causw)/setting/layout.tsx
@@ -6,8 +6,10 @@ export default function SettingLayout({
   children: React.ReactNode;
 }) {
   return (
-    <Flex justify="center" align="start" className="w-full">
-      <Flex className="w-full max-w-[900px] md:px-8 md:py-6">{children}</Flex>
+    <Flex justify="center" align="start" className="h-screen w-full">
+      <Flex className="h-full w-full max-w-[900px] md:px-8 md:py-6">
+        {children}
+      </Flex>
     </Flex>
   );
 }

--- a/apps/web/src/entities/notification/api/get.ts
+++ b/apps/web/src/entities/notification/api/get.ts
@@ -2,6 +2,7 @@ import { API } from '@/shared/api';
 
 import {
   NotificationLatestResponse,
+  NotificationSettingsResponse,
   NotificationUnreadCntResponse,
 } from '../model/types';
 
@@ -15,5 +16,12 @@ export const getNotificationLatest =
   async (): Promise<NotificationLatestResponse> => {
     return await API.get<NotificationLatestResponse>(
       '/api/v2/notifications/log/latest',
+    );
+  };
+
+export const getNotificationSettings =
+  async (): Promise<NotificationSettingsResponse> => {
+    return await API.get<NotificationSettingsResponse>(
+      '/api/v2/notification-settings',
     );
   };

--- a/apps/web/src/entities/notification/config/query-key/notificationQueryKey.ts
+++ b/apps/web/src/entities/notification/config/query-key/notificationQueryKey.ts
@@ -2,4 +2,5 @@ export const notificationQueryKey = {
   all: ['notification'] as const,
   unreadCounts: () => [...notificationQueryKey.all, 'unreadCnt'] as const,
   latest: () => [...notificationQueryKey.all, 'latest'] as const,
+  settings: () => [...notificationQueryKey.all, 'settings'] as const,
 };

--- a/apps/web/src/entities/notification/index.ts
+++ b/apps/web/src/entities/notification/index.ts
@@ -1,2 +1,4 @@
 export * from './model';
 export * from './lib';
+export * from './api';
+export * from './config';

--- a/apps/web/src/entities/notification/model/queries/index.ts
+++ b/apps/web/src/entities/notification/model/queries/index.ts
@@ -1,2 +1,3 @@
 export * from './useUnreadNotificationCnt';
 export * from './useLatestNotification';
+export * from './useNotificationSettings';

--- a/apps/web/src/entities/notification/model/queries/useNotificationSettings.ts
+++ b/apps/web/src/entities/notification/model/queries/useNotificationSettings.ts
@@ -1,0 +1,11 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { getNotificationSettings } from '../../api';
+import { notificationQueryKey } from '../../config';
+
+export const useNotificationSettings = () => {
+  return useSuspenseQuery({
+    queryKey: notificationQueryKey.settings(),
+    queryFn: getNotificationSettings,
+  });
+};

--- a/apps/web/src/entities/notification/model/queries/useUnreadNotificationCnt.ts
+++ b/apps/web/src/entities/notification/model/queries/useUnreadNotificationCnt.ts
@@ -1,11 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 
-import {
-  getNotificationUnreadCnt,
-  notificationQueryKey,
-} from '@/entities/notification';
-
 import { QUERY_STALE_TIME } from '@/shared/constants';
+
+import { getNotificationUnreadCnt } from '../../api';
+import { notificationQueryKey } from '../../config';
 
 export const useUnreadNotificationCnt = () => {
   return useQuery({

--- a/apps/web/src/entities/notification/model/queries/useUnreadNotificationCnt.ts
+++ b/apps/web/src/entities/notification/model/queries/useUnreadNotificationCnt.ts
@@ -1,9 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { QUERY_STALE_TIME } from '@/shared/constants';
+import {
+  getNotificationUnreadCnt,
+  notificationQueryKey,
+} from '@/entities/notification';
 
-import { getNotificationUnreadCnt } from '../../api';
-import { notificationQueryKey } from '../../config';
+import { QUERY_STALE_TIME } from '@/shared/constants';
 
 export const useUnreadNotificationCnt = () => {
   return useQuery({

--- a/apps/web/src/entities/notification/model/types/types.ts
+++ b/apps/web/src/entities/notification/model/types/types.ts
@@ -43,3 +43,14 @@ export interface NotificationSettingsResponse {
   service: ServiceNotificationSettings;
   officialBoards: OfficialBoardNotificationSettings[];
 }
+
+export interface UpdateNotificationSettingsRequest {
+  community?: Partial<CommunityNotificationSettings>;
+  ceremony?: Partial<CeremonyNotificationSettings>;
+  service?: Partial<ServiceNotificationSettings>;
+}
+
+export interface UpdateOfficialBoardNotificationRequest {
+  boardId: string;
+  subscribed: boolean;
+}

--- a/apps/web/src/entities/notification/model/types/types.ts
+++ b/apps/web/src/entities/notification/model/types/types.ts
@@ -16,3 +16,30 @@ export type NotificationType =
   | 'CEREMONY'
   | 'BOARD'
   | 'ADMISSION';
+
+export interface CommunityNotificationSettings {
+  likeOnMyPost: boolean;
+  commentOnMyPost: boolean;
+  replyOnMyComment: boolean;
+}
+
+export interface CeremonyNotificationSettings {
+  enabled: boolean;
+}
+
+export interface ServiceNotificationSettings {
+  noticeEnabled: boolean;
+}
+
+export interface OfficialBoardNotificationSettings {
+  boardId: string;
+  name: string;
+  subscribed: boolean;
+}
+
+export interface NotificationSettingsResponse {
+  community: CommunityNotificationSettings;
+  ceremony: CeremonyNotificationSettings;
+  service: ServiceNotificationSettings;
+  officialBoards: OfficialBoardNotificationSettings[];
+}

--- a/apps/web/src/features/notification/api/index.ts
+++ b/apps/web/src/features/notification/api/index.ts
@@ -1,0 +1,1 @@
+export * from './patch';

--- a/apps/web/src/features/notification/api/patch.ts
+++ b/apps/web/src/features/notification/api/patch.ts
@@ -1,0 +1,22 @@
+import {
+  type UpdateNotificationSettingsRequest,
+  type UpdateOfficialBoardNotificationRequest,
+} from '@/entities/notification';
+
+import { API } from '@/shared/api';
+
+export const updateNotificationSettings = async (
+  body: UpdateNotificationSettingsRequest,
+) => {
+  return await API.patch<null>('/api/v2/notification-settings', body);
+};
+
+export const updateOfficialBoardNotification = async ({
+  boardId,
+  subscribed,
+}: UpdateOfficialBoardNotificationRequest) => {
+  return await API.patch<null>(
+    `/api/v2/notification-settings/official-boards/${boardId}`,
+    { subscribed },
+  );
+};

--- a/apps/web/src/features/notification/index.ts
+++ b/apps/web/src/features/notification/index.ts
@@ -1,0 +1,2 @@
+export * from './api';
+export * from './model';

--- a/apps/web/src/features/notification/model/index.ts
+++ b/apps/web/src/features/notification/model/index.ts
@@ -1,0 +1,1 @@
+export * from './mutations';

--- a/apps/web/src/features/notification/model/mutations/index.ts
+++ b/apps/web/src/features/notification/model/mutations/index.ts
@@ -1,0 +1,1 @@
+export * from './useNotificationSettingsOptimisticMutations';

--- a/apps/web/src/features/notification/model/mutations/useNotificationSettingsOptimisticMutations.ts
+++ b/apps/web/src/features/notification/model/mutations/useNotificationSettingsOptimisticMutations.ts
@@ -1,0 +1,134 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import {
+  type NotificationSettingsResponse,
+  type UpdateNotificationSettingsRequest,
+  type UpdateOfficialBoardNotificationRequest,
+} from '@/entities/notification';
+import { notificationQueryKey } from '@/entities/notification/config';
+
+import { toast } from '@/shared/model';
+import { extractErrorMessage } from '@/shared/utils';
+
+import {
+  updateNotificationSettings,
+  updateOfficialBoardNotification,
+} from '../../api';
+
+export const useNotificationSettingsOptimisticMutations = () => {
+  const queryClient = useQueryClient();
+
+  const notificationSettingsMutation = useMutation({
+    mutationFn: (body: UpdateNotificationSettingsRequest) =>
+      updateNotificationSettings(body),
+    onMutate: async (body) => {
+      await queryClient.cancelQueries({
+        queryKey: notificationQueryKey.settings(),
+      });
+
+      const previousSettings =
+        queryClient.getQueryData<NotificationSettingsResponse>(
+          notificationQueryKey.settings(),
+        );
+
+      if (previousSettings) {
+        queryClient.setQueryData<NotificationSettingsResponse>(
+          notificationQueryKey.settings(),
+          {
+            ...previousSettings,
+            community: {
+              ...previousSettings.community,
+              ...body.community,
+            },
+            ceremony: {
+              ...previousSettings.ceremony,
+              ...body.ceremony,
+            },
+            service: {
+              ...previousSettings.service,
+              ...body.service,
+            },
+          },
+        );
+      }
+
+      return { previousSettings };
+    },
+    onError: (error, _body, context) => {
+      if (context?.previousSettings) {
+        queryClient.setQueryData(
+          notificationQueryKey.settings(),
+          context.previousSettings,
+        );
+      }
+
+      toast.error(
+        extractErrorMessage(
+          error,
+          '알림 설정 변경에 실패했습니다. 잠시 후 다시 시도해주세요.',
+        ),
+      );
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: notificationQueryKey.settings(),
+      });
+    },
+  });
+
+  const officialBoardMutation = useMutation({
+    mutationFn: (body: UpdateOfficialBoardNotificationRequest) =>
+      updateOfficialBoardNotification(body),
+    onMutate: async ({ boardId, subscribed }) => {
+      await queryClient.cancelQueries({
+        queryKey: notificationQueryKey.settings(),
+      });
+
+      const previousSettings =
+        queryClient.getQueryData<NotificationSettingsResponse>(
+          notificationQueryKey.settings(),
+        );
+
+      if (previousSettings) {
+        queryClient.setQueryData<NotificationSettingsResponse>(
+          notificationQueryKey.settings(),
+          {
+            ...previousSettings,
+            officialBoards: previousSettings.officialBoards.map((board) =>
+              board.boardId === boardId ? { ...board, subscribed } : board,
+            ),
+          },
+        );
+      }
+
+      return { previousSettings };
+    },
+    onError: (error, _body, context) => {
+      if (context?.previousSettings) {
+        queryClient.setQueryData(
+          notificationQueryKey.settings(),
+          context.previousSettings,
+        );
+      }
+
+      toast.error(
+        extractErrorMessage(
+          error,
+          '공식 계정 알림 설정 변경에 실패했습니다. 잠시 후 다시 시도해주세요.',
+        ),
+      );
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: notificationQueryKey.settings(),
+      });
+    },
+  });
+
+  return {
+    updateNotificationSettings: notificationSettingsMutation.mutate,
+    updateOfficialBoardNotification: officialBoardMutation.mutate,
+    isUpdatingNotificationSettings: notificationSettingsMutation.isPending,
+    isUpdatingOfficialBoards: officialBoardMutation.isPending,
+  };
+};

--- a/apps/web/src/features/notification/model/mutations/useNotificationSettingsOptimisticMutations.ts
+++ b/apps/web/src/features/notification/model/mutations/useNotificationSettingsOptimisticMutations.ts
@@ -4,8 +4,8 @@ import {
   type NotificationSettingsResponse,
   type UpdateNotificationSettingsRequest,
   type UpdateOfficialBoardNotificationRequest,
+  notificationQueryKey,
 } from '@/entities/notification';
-import { notificationQueryKey } from '@/entities/notification/config';
 
 import { toast } from '@/shared/model';
 import { extractErrorMessage } from '@/shared/utils';

--- a/apps/web/src/shared/lib/capacitor/push-notification/notification.ts
+++ b/apps/web/src/shared/lib/capacitor/push-notification/notification.ts
@@ -1,4 +1,9 @@
-import { PushNotifications, type Token } from '@capacitor/push-notifications';
+import type { PermissionState } from '@capacitor/core';
+import {
+  PushNotifications,
+  type PermissionStatus,
+  type Token,
+} from '@capacitor/push-notifications';
 
 import { isMobile } from '@/shared/utils';
 
@@ -8,6 +13,23 @@ type InitNotificationOptions = {
 };
 
 let registered = false;
+
+async function getPushNotificationPermissionState(): Promise<
+  PermissionState | 'unsupported'
+> {
+  if (!isMobile) return 'unsupported';
+
+  const permission: PermissionStatus =
+    await PushNotifications.checkPermissions();
+
+  return permission.receive;
+}
+
+export async function isPushNotificationPermissionDenied() {
+  const status = await getPushNotificationPermissionState();
+
+  return status === 'denied';
+}
 
 export async function initNotification({
   onToken,

--- a/apps/web/src/shared/ui/provider/index.ts
+++ b/apps/web/src/shared/ui/provider/index.ts
@@ -2,4 +2,5 @@ export {
   QueryErrorBoundary,
   QueryProviderWithDevtools,
 } from './tanstack-query';
+export { HydrationSuspense } from './suspense/HydrationSuspense';
 export { Toaster } from './toast';

--- a/apps/web/src/shared/ui/provider/suspense/HydrationSuspense.tsx
+++ b/apps/web/src/shared/ui/provider/suspense/HydrationSuspense.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Suspense, useSyncExternalStore, type ReactNode } from 'react';
+
+const subscribe = () => () => {};
+const getSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+const useIsHydrated = () =>
+  useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+interface HydrationSuspenseProps {
+  fallback: ReactNode;
+  children: ReactNode;
+}
+
+export const HydrationSuspense = ({
+  fallback,
+  children,
+}: HydrationSuspenseProps) => {
+  const isHydrated = useIsHydrated();
+
+  if (isHydrated) {
+    return <Suspense fallback={fallback}>{children}</Suspense>;
+  }
+
+  return <>{null}</>;
+};

--- a/apps/web/src/widgets/setting/config/constants.ts
+++ b/apps/web/src/widgets/setting/config/constants.ts
@@ -20,24 +20,15 @@ export const SETTING_NOTIFICATIONS = {
   title: '알림 설정',
   community: {
     title: '커뮤니티 알림',
-    items: [
-      '내 글에 좋아요',
-      '내 글에 댓글',
-      '내 글에 대댓글',
-      '내 글에 대댓글',
-    ],
   },
   official: {
     title: '공식계정 글 알림',
-    items: ['학생회', '소프트웨어학부', '딜리버드', '크자회'],
   },
   notice: {
     title: '공지',
-    items: ['서비스 공지, 계정 상태'],
   },
   event: {
     title: '경조사 알림',
-    items: ['경조사 알림 받기'],
   },
 } as const;
 

--- a/apps/web/src/widgets/setting/config/constants.ts
+++ b/apps/web/src/widgets/setting/config/constants.ts
@@ -25,7 +25,7 @@ export const SETTING_NOTIFICATIONS = {
     title: '공식계정 글 알림',
   },
   notice: {
-    title: '공지',
+    title: '시스템 알림',
   },
   event: {
     title: '경조사 알림',

--- a/apps/web/src/widgets/setting/ui/setting-notifications/CommunityNotificationSection.tsx
+++ b/apps/web/src/widgets/setting/ui/setting-notifications/CommunityNotificationSection.tsx
@@ -6,10 +6,12 @@ import { SETTING_NOTIFICATIONS } from '../../config';
 
 type CommunityNotificationSectionProps = {
   settings: CommunityNotificationSettings;
+  onToggle: (key: keyof CommunityNotificationSettings, checked: boolean) => void;
 };
 
 export const CommunityNotificationSection = ({
   settings,
+  onToggle,
 }: CommunityNotificationSectionProps) => {
   return (
     <VStack className="gap-5 rounded-lg bg-white p-5">
@@ -17,17 +19,33 @@ export const CommunityNotificationSection = ({
         {SETTING_NOTIFICATIONS.community.title}
       </Text>
       <VStack className="gap-6">
-        <Toggle checked={settings.likeOnMyPost} className="justify-between">
+        <Toggle
+          checked={settings.likeOnMyPost}
+          onCheckedChange={(checked) => onToggle('likeOnMyPost', Boolean(checked))}
+          className="justify-between"
+        >
           <Toggle.Label typography="body-16-medium">
             내 글에 좋아요
           </Toggle.Label>
           <Toggle.Switch />
         </Toggle>
-        <Toggle checked={settings.commentOnMyPost} className="justify-between">
+        <Toggle
+          checked={settings.commentOnMyPost}
+          onCheckedChange={(checked) =>
+            onToggle('commentOnMyPost', Boolean(checked))
+          }
+          className="justify-between"
+        >
           <Toggle.Label typography="body-16-medium">내 글에 댓글</Toggle.Label>
           <Toggle.Switch />
         </Toggle>
-        <Toggle checked={settings.replyOnMyComment} className="justify-between">
+        <Toggle
+          checked={settings.replyOnMyComment}
+          onCheckedChange={(checked) =>
+            onToggle('replyOnMyComment', Boolean(checked))
+          }
+          className="justify-between"
+        >
           <Toggle.Label typography="body-16-medium">
             내 글에 대댓글
           </Toggle.Label>

--- a/apps/web/src/widgets/setting/ui/setting-notifications/CommunityNotificationSection.tsx
+++ b/apps/web/src/widgets/setting/ui/setting-notifications/CommunityNotificationSection.tsx
@@ -1,20 +1,38 @@
 import { Text, Toggle, VStack } from '@causw/cds';
 
+import { type CommunityNotificationSettings } from '@/entities/notification';
+
 import { SETTING_NOTIFICATIONS } from '../../config';
 
-export const CommunityNotificationSection = () => {
+type CommunityNotificationSectionProps = {
+  settings: CommunityNotificationSettings;
+};
+
+export const CommunityNotificationSection = ({
+  settings,
+}: CommunityNotificationSectionProps) => {
   return (
     <VStack className="gap-5 rounded-lg bg-white p-5">
       <Text typography="body-14-regular" textColor="gray-500">
         {SETTING_NOTIFICATIONS.community.title}
       </Text>
       <VStack className="gap-6">
-        {SETTING_NOTIFICATIONS.community.items.map((item, index) => (
-          <Toggle key={`${item}-${index}`} className="justify-between">
-            <Toggle.Label typography="body-16-medium">{item}</Toggle.Label>
-            <Toggle.Switch />
-          </Toggle>
-        ))}
+        <Toggle checked={settings.likeOnMyPost} className="justify-between">
+          <Toggle.Label typography="body-16-medium">
+            내 글에 좋아요
+          </Toggle.Label>
+          <Toggle.Switch />
+        </Toggle>
+        <Toggle checked={settings.commentOnMyPost} className="justify-between">
+          <Toggle.Label typography="body-16-medium">내 글에 댓글</Toggle.Label>
+          <Toggle.Switch />
+        </Toggle>
+        <Toggle checked={settings.replyOnMyComment} className="justify-between">
+          <Toggle.Label typography="body-16-medium">
+            내 글에 대댓글
+          </Toggle.Label>
+          <Toggle.Switch />
+        </Toggle>
       </VStack>
     </VStack>
   );

--- a/apps/web/src/widgets/setting/ui/setting-notifications/EventNotificationSection.tsx
+++ b/apps/web/src/widgets/setting/ui/setting-notifications/EventNotificationSection.tsx
@@ -1,20 +1,28 @@
 import { Text, Toggle, VStack } from '@causw/cds';
 
+import { type CeremonyNotificationSettings } from '@/entities/notification';
+
 import { SETTING_NOTIFICATIONS } from '../../config';
 
-export const EventNotificationSection = () => {
+type EventNotificationSectionProps = {
+  settings: CeremonyNotificationSettings;
+};
+
+export const EventNotificationSection = ({
+  settings,
+}: EventNotificationSectionProps) => {
   return (
     <VStack className="gap-5 rounded-lg bg-white p-5">
       <Text typography="body-14-regular" textColor="gray-500">
         {SETTING_NOTIFICATIONS.event.title}
       </Text>
       <VStack className="gap-6">
-        {SETTING_NOTIFICATIONS.event.items.map((item) => (
-          <Toggle key={item} className="justify-between">
-            <Toggle.Label typography="body-16-medium">{item}</Toggle.Label>
-            <Toggle.Switch />
-          </Toggle>
-        ))}
+        <Toggle checked={settings.enabled} className="justify-between">
+          <Toggle.Label typography="body-16-medium">
+            경조사 알림 받기
+          </Toggle.Label>
+          <Toggle.Switch />
+        </Toggle>
       </VStack>
     </VStack>
   );

--- a/apps/web/src/widgets/setting/ui/setting-notifications/EventNotificationSection.tsx
+++ b/apps/web/src/widgets/setting/ui/setting-notifications/EventNotificationSection.tsx
@@ -6,10 +6,12 @@ import { SETTING_NOTIFICATIONS } from '../../config';
 
 type EventNotificationSectionProps = {
   settings: CeremonyNotificationSettings;
+  onToggle: (checked: boolean) => void;
 };
 
 export const EventNotificationSection = ({
   settings,
+  onToggle,
 }: EventNotificationSectionProps) => {
   return (
     <VStack className="gap-5 rounded-lg bg-white p-5">
@@ -17,7 +19,11 @@ export const EventNotificationSection = ({
         {SETTING_NOTIFICATIONS.event.title}
       </Text>
       <VStack className="gap-6">
-        <Toggle checked={settings.enabled} className="justify-between">
+        <Toggle
+          checked={settings.enabled}
+          onCheckedChange={(checked) => onToggle(Boolean(checked))}
+          className="justify-between"
+        >
           <Toggle.Label typography="body-16-medium">
             경조사 알림 받기
           </Toggle.Label>

--- a/apps/web/src/widgets/setting/ui/setting-notifications/NoticeNotificationSection.tsx
+++ b/apps/web/src/widgets/setting/ui/setting-notifications/NoticeNotificationSection.tsx
@@ -1,20 +1,28 @@
 import { Text, Toggle, VStack } from '@causw/cds';
 
+import { type ServiceNotificationSettings } from '@/entities/notification';
+
 import { SETTING_NOTIFICATIONS } from '../../config';
 
-export const NoticeNotificationSection = () => {
+type NoticeNotificationSectionProps = {
+  settings: ServiceNotificationSettings;
+};
+
+export const NoticeNotificationSection = ({
+  settings,
+}: NoticeNotificationSectionProps) => {
   return (
     <VStack className="gap-5 rounded-lg bg-white p-5">
       <Text typography="body-14-regular" textColor="gray-500">
         {SETTING_NOTIFICATIONS.notice.title}
       </Text>
       <VStack className="gap-6">
-        {SETTING_NOTIFICATIONS.notice.items.map((item) => (
-          <Toggle key={item} className="justify-between">
-            <Toggle.Label typography="body-16-medium">{item}</Toggle.Label>
-            <Toggle.Switch />
-          </Toggle>
-        ))}
+        <Toggle checked={settings.noticeEnabled} className="justify-between">
+          <Toggle.Label typography="body-16-medium">
+            서비스 공지, 계정 상태
+          </Toggle.Label>
+          <Toggle.Switch />
+        </Toggle>
       </VStack>
     </VStack>
   );

--- a/apps/web/src/widgets/setting/ui/setting-notifications/NoticeNotificationSection.tsx
+++ b/apps/web/src/widgets/setting/ui/setting-notifications/NoticeNotificationSection.tsx
@@ -6,10 +6,12 @@ import { SETTING_NOTIFICATIONS } from '../../config';
 
 type NoticeNotificationSectionProps = {
   settings: ServiceNotificationSettings;
+  onToggle: (checked: boolean) => void;
 };
 
 export const NoticeNotificationSection = ({
   settings,
+  onToggle,
 }: NoticeNotificationSectionProps) => {
   return (
     <VStack className="gap-5 rounded-lg bg-white p-5">
@@ -17,7 +19,11 @@ export const NoticeNotificationSection = ({
         {SETTING_NOTIFICATIONS.notice.title}
       </Text>
       <VStack className="gap-6">
-        <Toggle checked={settings.noticeEnabled} className="justify-between">
+        <Toggle
+          checked={settings.noticeEnabled}
+          onCheckedChange={(checked) => onToggle(Boolean(checked))}
+          className="justify-between"
+        >
           <Toggle.Label typography="body-16-medium">
             서비스 공지, 계정 상태
           </Toggle.Label>

--- a/apps/web/src/widgets/setting/ui/setting-notifications/OfficialAccountNotificationSection.tsx
+++ b/apps/web/src/widgets/setting/ui/setting-notifications/OfficialAccountNotificationSection.tsx
@@ -1,17 +1,33 @@
 import { Text, Toggle, VStack } from '@causw/cds';
 
+import { type OfficialBoardNotificationSettings } from '@/entities/notification';
+
 import { SETTING_NOTIFICATIONS } from '../../config';
 
-export const OfficialAccountNotificationSection = () => {
+type OfficialAccountNotificationSectionProps = {
+  boards: OfficialBoardNotificationSettings[];
+};
+
+export const OfficialAccountNotificationSection = ({
+  boards,
+}: OfficialAccountNotificationSectionProps) => {
+  if (boards.length === 0) return null;
+
   return (
     <VStack className="gap-5 rounded-lg bg-white p-5">
       <Text typography="body-14-regular" textColor="gray-500">
         {SETTING_NOTIFICATIONS.official.title}
       </Text>
       <VStack className="gap-6">
-        {SETTING_NOTIFICATIONS.official.items.map((item) => (
-          <Toggle key={item} className="justify-between">
-            <Toggle.Label typography="body-16-medium">{item}</Toggle.Label>
+        {boards.map((board) => (
+          <Toggle
+            key={board.boardId}
+            checked={board.subscribed}
+            className="justify-between"
+          >
+            <Toggle.Label typography="body-16-medium">
+              {board.name}
+            </Toggle.Label>
             <Toggle.Switch />
           </Toggle>
         ))}

--- a/apps/web/src/widgets/setting/ui/setting-notifications/OfficialAccountNotificationSection.tsx
+++ b/apps/web/src/widgets/setting/ui/setting-notifications/OfficialAccountNotificationSection.tsx
@@ -6,10 +6,12 @@ import { SETTING_NOTIFICATIONS } from '../../config';
 
 type OfficialAccountNotificationSectionProps = {
   boards: OfficialBoardNotificationSettings[];
+  onToggle: (boardId: string, checked: boolean) => void;
 };
 
 export const OfficialAccountNotificationSection = ({
   boards,
+  onToggle,
 }: OfficialAccountNotificationSectionProps) => {
   if (boards.length === 0) return null;
 
@@ -23,6 +25,9 @@ export const OfficialAccountNotificationSection = ({
           <Toggle
             key={board.boardId}
             checked={board.subscribed}
+            onCheckedChange={(checked) =>
+              onToggle(board.boardId, Boolean(checked))
+            }
             className="justify-between"
           >
             <Toggle.Label typography="body-16-medium">

--- a/apps/web/src/widgets/setting/ui/setting-notifications/PushNotificationPermissionNotice.tsx
+++ b/apps/web/src/widgets/setting/ui/setting-notifications/PushNotificationPermissionNotice.tsx
@@ -1,0 +1,33 @@
+import {
+  ArrowRight,
+  BellColored,
+  Flex,
+  HStack,
+  Text,
+  VStack,
+} from '@causw/cds';
+
+export const PushNotificationPermissionNotice = () => {
+  return (
+    <HStack align="center" className="gap-3 rounded-lg bg-white p-4">
+      <Flex
+        align="center"
+        justify="center"
+        className="h-[40px] w-[40px] rounded-md bg-gray-100 p-2"
+      >
+        <BellColored size={24} />
+      </Flex>
+      <VStack className="gap-0.5">
+        <Text typography="body-15-semibold" textColor="gray-700">
+          먼저 알림을 켜주세요.
+        </Text>
+        <Text typography="body-14-regular" textColor="gray-500">
+          OS 설정에서 알림을 활성화해주세요.
+        </Text>
+      </VStack>
+      <Flex align="center" justify="center" className="ml-auto">
+        <ArrowRight size={24} />
+      </Flex>
+    </HStack>
+  );
+};

--- a/apps/web/src/widgets/setting/ui/setting-notifications/index.ts
+++ b/apps/web/src/widgets/setting/ui/setting-notifications/index.ts
@@ -2,3 +2,4 @@ export * from './CommunityNotificationSection';
 export * from './OfficialAccountNotificationSection';
 export * from './NoticeNotificationSection';
 export * from './EventNotificationSection';
+export * from './PushNotificationPermissionNotice';


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #119 


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 알림 설정 페이지 api 연동


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.
[알림 페이지]
- 알림 설정 페이지 api 호출 정의 
- 알림 설정 페이지 mutations 호출 정의 ( Optimistic update 활용 )
- 기존 알림 설정 페이지에 api 연동

[setting 레이아웃 수정]
- 세팅 쪽 레이아웃에서 height값 수정

[ 공용 컴포넌트 ]
- useSuspenseQuery와 호환가능한 suspenseWrapper(HydrationSuspense) 추가 


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.
- 낙관적 업데이트 적용된 로직 한 번 체크 부탁드립니다
- hydrationSuspense도 한 번 확인 해주세요


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.


## 📎 Additional Notes
-
