### PR TITLE
[FEAT/#155] 게시글 댓글 신고 및 차단 api 연동

### DIFF
--- a/apps/web/src/entities/comment/ui/CommentCard.tsx
+++ b/apps/web/src/entities/comment/ui/CommentCard.tsx
@@ -38,63 +38,63 @@ export const CommentCard = ({
   return (
     <article className={`bg-white px-5 py-3 ${isReply && 'pl-12'}`}>
       <HStack align={isInactive ? 'center' : 'start'} className="gap-3">
+        <Avatar
+          size={36}
+          src={profileImage}
+          className="my-1 shrink-0"
+          isRestricted={isBlocked}
+        />
         {isInactive ? (
-          <>
-            <Avatar size={36} className="my-1 shrink-0" />
+          <VStack gap="none">
+            <Text typography="body-15-regular" textColor="gray-400">
+              {isDeleted ? '삭제된 댓글입니다' : '차단된 사용자의 댓글입니다'}
+            </Text>
+          </VStack>
+        ) : (
+          <VStack className="w-full gap-3">
             <VStack gap="none">
-              <Text typography="body-15-regular" textColor="gray-400">
-                {isDeleted ? '삭제된 댓글입니다' : '차단된 사용자의 댓글입니다'}
+              <HStack align="center" justify="between">
+                <HStack gap="sm" align="center">
+                  <Text typography="body-15-semibold" textColor="gray-800">
+                    {author}
+                  </Text>
+                  <Text typography="body-15-regular" textColor="gray-500">
+                    {time}
+                  </Text>
+                </HStack>
+
+                {menuSlot}
+              </HStack>
+              <Text
+                typography="body-15-regular"
+                textColor="gray-800"
+                className="whitespace-pre-wrap"
+              >
+                {content}
               </Text>
             </VStack>
-          </>
-        ) : (
-          <>
-            <Avatar size={36} src={profileImage} className="my-1 shrink-0" />
-            <VStack className="w-full gap-3">
-              <VStack gap="none">
-                <HStack align="center" justify="between">
-                  <HStack gap="sm" align="center">
-                    <Text typography="body-15-semibold" textColor="gray-800">
-                      {author}
-                    </Text>
-                    <Text typography="body-15-regular" textColor="gray-500">
-                      {time}
-                    </Text>
-                  </HStack>
 
-                  {menuSlot}
-                </HStack>
-                <Text
-                  typography="body-15-regular"
-                  textColor="gray-800"
-                  className="whitespace-pre-wrap"
+            <HStack align="center" justify={isReply ? 'end' : 'between'}>
+              {!isReply && (
+                <button
+                  type="button"
+                  onClick={onReplyClick}
+                  className="cursor-pointer transition-opacity hover:opacity-70 active:opacity-70"
                 >
-                  {content}
-                </Text>
-              </VStack>
+                  <Text typography="body-14-medium" textColor="gray-400">
+                    답글달기
+                  </Text>
+                </button>
+              )}
 
-              <HStack align="center" justify={isReply ? 'end' : 'between'}>
-                {!isReply && (
-                  <button
-                    type="button"
-                    onClick={onReplyClick}
-                    className="cursor-pointer transition-opacity hover:opacity-70 active:opacity-70"
-                  >
-                    <Text typography="body-14-medium" textColor="gray-400">
-                      답글달기
-                    </Text>
-                  </button>
-                )}
-
-                <IconCountButton
-                  icon={<Heart />}
-                  count={likeCount}
-                  active={isLiked}
-                  onClick={onLikeClick}
-                />
-              </HStack>
-            </VStack>
-          </>
+              <IconCountButton
+                icon={<Heart />}
+                count={likeCount}
+                active={isLiked}
+                onClick={onLikeClick}
+              />
+            </HStack>
+          </VStack>
         )}
       </HStack>
     </article>

--- a/apps/web/src/entities/report/model/types/index.ts
+++ b/apps/web/src/entities/report/model/types/index.ts
@@ -15,3 +15,29 @@ export interface ReportPostResponseDto {
   reportReason: ReportReason;
   createdAt: string;
 }
+
+/* 댓글 신고 */
+export interface ReportCommentRequestDto {
+  commentId: string;
+  reportReason: ReportReason;
+}
+
+export interface ReportCommentResponseDto {
+  reportId: string;
+  commentId: string;
+  reportReason: ReportReason;
+  createdAt: string;
+}
+
+/* 답글 신고 */
+export interface ReportChildCommentRequestDto {
+  childCommentId: string;
+  reportReason: ReportReason;
+}
+
+export interface ReportChildCommentResponseDto {
+  reportId: string;
+  childCommentId: string;
+  reportReason: ReportReason;
+  createdAt: string;
+}

--- a/apps/web/src/features/block/api/post/index.ts
+++ b/apps/web/src/features/block/api/post/index.ts
@@ -6,7 +6,25 @@ export const blockUserByPost = async (
   postId: string,
 ): Promise<BlockUserResponseDto> => {
   const data = await API.post<BlockUserResponseDto>(
-    `/api/v2/blocks/by-post/${postId}`,
+    `/api/v2/posts/${postId}/blocks`,
+  );
+  return data;
+};
+
+export const blockUserByComment = async (
+  commentId: string,
+): Promise<BlockUserResponseDto> => {
+  const data = await API.post<BlockUserResponseDto>(
+    `/api/v2/comments/${commentId}/blocks`,
+  );
+  return data;
+};
+
+export const blockUserByReply = async (
+  childCommentId: string,
+): Promise<BlockUserResponseDto> => {
+  const data = await API.post<BlockUserResponseDto>(
+    `/api/v2/child-comments/${childCommentId}/blocks`,
   );
   return data;
 };

--- a/apps/web/src/features/block/model/mutations/index.ts
+++ b/apps/web/src/features/block/model/mutations/index.ts
@@ -1,1 +1,3 @@
 export * from './useBlockUserByPostMutation';
+export * from './useBlockUserByCommentMutation';
+export * from './useBlockUserByReplyMutation';

--- a/apps/web/src/features/block/model/mutations/useBlockUserByCommentMutation.ts
+++ b/apps/web/src/features/block/model/mutations/useBlockUserByCommentMutation.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { useMutation } from '@tanstack/react-query';
+
+import { toast } from '@/shared/model';
+
+import { blockUserByComment } from '../../api';
+
+export const useBlockUserByCommentMutation = () => {
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: (commentId: string) => blockUserByComment(commentId),
+
+    onSuccess: () => {
+      toast.success('작성자를 차단했어요.');
+      router.push('/feed');
+    },
+
+    onError: () => {
+      toast.error('작성자 차단에 실패했어요.');
+    },
+  });
+};

--- a/apps/web/src/features/block/model/mutations/useBlockUserByCommentMutation.ts
+++ b/apps/web/src/features/block/model/mutations/useBlockUserByCommentMutation.ts
@@ -1,22 +1,24 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { useMutation } from '@tanstack/react-query';
+import { commentKeys } from '@/entities/comment';
 
 import { toast } from '@/shared/model';
 
 import { blockUserByComment } from '../../api';
 
-export const useBlockUserByCommentMutation = () => {
-  const router = useRouter();
+export const useBlockUserByCommentMutation = (postId: string) => {
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (commentId: string) => blockUserByComment(commentId),
 
     onSuccess: () => {
       toast.success('작성자를 차단했어요.');
-      router.push('/feed');
+      queryClient.invalidateQueries({
+        queryKey: commentKeys.post(postId),
+      });
     },
 
     onError: () => {

--- a/apps/web/src/features/block/model/mutations/useBlockUserByReplyMutation.ts
+++ b/apps/web/src/features/block/model/mutations/useBlockUserByReplyMutation.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { useMutation } from '@tanstack/react-query';
+
+import { toast } from '@/shared/model';
+
+import { blockUserByReply } from '../../api';
+
+export const useBlockUserByReplyMutation = () => {
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: (childCommentId: string) => blockUserByReply(childCommentId),
+
+    onSuccess: () => {
+      toast.success('작성자를 차단했어요.');
+      router.push('/feed');
+    },
+
+    onError: () => {
+      toast.error('작성자 차단에 실패했어요.');
+    },
+  });
+};

--- a/apps/web/src/features/block/model/mutations/useBlockUserByReplyMutation.ts
+++ b/apps/web/src/features/block/model/mutations/useBlockUserByReplyMutation.ts
@@ -1,22 +1,24 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { useMutation } from '@tanstack/react-query';
+import { commentKeys } from '@/entities/comment';
 
 import { toast } from '@/shared/model';
 
 import { blockUserByReply } from '../../api';
 
-export const useBlockUserByReplyMutation = () => {
-  const router = useRouter();
+export const useBlockUserByReplyMutation = (postId: string) => {
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (childCommentId: string) => blockUserByReply(childCommentId),
 
     onSuccess: () => {
       toast.success('작성자를 차단했어요.');
-      router.push('/feed');
+      queryClient.invalidateQueries({
+        queryKey: commentKeys.post(postId),
+      });
     },
 
     onError: () => {

--- a/apps/web/src/features/comment/model/hooks/useCommentMenuActions.ts
+++ b/apps/web/src/features/comment/model/hooks/useCommentMenuActions.ts
@@ -2,6 +2,17 @@
 
 import { useState } from 'react';
 
+import {
+  useBlockUserByCommentMutation,
+  useBlockUserByReplyMutation,
+} from '@/features/block';
+import {
+  useReportCommentMutation,
+  useReportReplyMutation,
+} from '@/features/report';
+
+import { type ReportReason } from '@/entities/report';
+
 import { type CommentAction } from '../../config';
 import { useDeleteCommentMutation, useDeleteReplyMutation } from '../mutations';
 
@@ -16,9 +27,19 @@ export const useCommentMenuActions = (
 
   const { mutate: deleteComment } = useDeleteCommentMutation(postId);
   const { mutate: deleteReply } = useDeleteReplyMutation(postId);
+  const { mutate: reportComment } = useReportCommentMutation();
+  const { mutate: reportReply } = useReportReplyMutation();
+  const { mutate: blockUserByComment } = useBlockUserByCommentMutation();
+  const { mutate: blockUserByReply } = useBlockUserByReplyMutation();
 
   const handleAction = (action: CommentAction) => {
-    setActiveModal(action);
+    switch (action) {
+      case 'report':
+      case 'block':
+      case 'delete':
+        setActiveModal(action);
+        break;
+    }
   };
 
   const closeModal = () => setActiveModal(null);
@@ -32,15 +53,21 @@ export const useCommentMenuActions = (
     closeModal();
   };
 
-  const submitReport = () => {
-    console.log(`${targetId}번 댓글 신고 제출`);
-    // TODO: 신고 API mutation 호출
+  const submitReport = (reason: ReportReason) => {
+    if (isReply) {
+      reportReply({ childCommentId: targetId, reportReason: reason });
+    } else {
+      reportComment({ commentId: targetId, reportReason: reason });
+    }
     closeModal();
   };
 
   const submitBlock = () => {
-    console.log(`${targetId}번 댓글 작성자 차단`);
-    // TODO: 차단 API mutation 호출
+    if (isReply) {
+      blockUserByReply(targetId);
+    } else {
+      blockUserByComment(targetId);
+    }
     closeModal();
   };
 

--- a/apps/web/src/features/comment/model/hooks/useCommentMenuActions.ts
+++ b/apps/web/src/features/comment/model/hooks/useCommentMenuActions.ts
@@ -29,8 +29,8 @@ export const useCommentMenuActions = (
   const { mutate: deleteReply } = useDeleteReplyMutation(postId);
   const { mutate: reportComment } = useReportCommentMutation();
   const { mutate: reportReply } = useReportReplyMutation();
-  const { mutate: blockUserByComment } = useBlockUserByCommentMutation();
-  const { mutate: blockUserByReply } = useBlockUserByReplyMutation();
+  const { mutate: blockUserByComment } = useBlockUserByCommentMutation(postId);
+  const { mutate: blockUserByReply } = useBlockUserByReplyMutation(postId);
 
   const handleAction = (action: CommentAction) => {
     switch (action) {

--- a/apps/web/src/features/post/ui/PostWriteFooter.tsx
+++ b/apps/web/src/features/post/ui/PostWriteFooter.tsx
@@ -1,15 +1,15 @@
-import { Button, Camera, Checkbox, HStack, Vote } from '@causw/cds';
+import { Button, Camera, Checkbox, HStack } from '@causw/cds';
 
 interface PostWriteFooterProps {
   onClickPhoto: () => void;
-  onClickVote: () => void;
+  // onClickVote: () => void;
   isAnonymous: boolean;
   onChangeAnonymous: (checked: boolean) => void;
 }
 
 export const PostWriteFooter = ({
   onClickPhoto,
-  onClickVote,
+  // onClickVote,
   isAnonymous,
   onChangeAnonymous,
 }: PostWriteFooterProps) => {
@@ -20,10 +20,11 @@ export const PostWriteFooter = ({
           <Camera active size={16} />
           사진첨부
         </Button>
+        {/* TODO: 투표 기능 API 구현/연동 완료 시 주석 해제
         <Button type="button" onClick={onClickVote} className="text-gray-500">
           <Vote active size={16} />
           투표
-        </Button>
+        </Button> */}
       </HStack>
       <Checkbox
         checked={isAnonymous}

--- a/apps/web/src/features/post/ui/PostWriteForm.tsx
+++ b/apps/web/src/features/post/ui/PostWriteForm.tsx
@@ -11,7 +11,7 @@ import { type PostCreateFormValues, usePostCreateForm } from '@/entities/post';
 
 import { ImageUploadField, type ImageUploadFieldRef } from '@/shared/ui';
 
-import { createEmptyVote } from '../lib';
+// import { createEmptyVote } from '../lib';
 import { mapPostCreateFormToDto, mapPostUpdateFormToDto } from '../lib/mappers';
 import { useCreatePostMutation, useUpdatePostMutation } from '../model';
 
@@ -127,14 +127,15 @@ export const PostWriteForm = ({
         <Dialog.Footer>
           <PostWriteFooter
             onClickPhoto={() => imageUploadRef.current?.openFilePicker()}
-            onClickVote={() => {
-              if (!currentVote) {
-                setValue('vote', createEmptyVote(), {
-                  shouldValidate: true,
-                  shouldDirty: true,
-                });
-              }
-            }}
+            // TODO: 투표 기능 API 구현/연동 완료 시 주석 해제
+            // onClickVote={() => {
+            //   if (!currentVote) {
+            //     setValue('vote', createEmptyVote(), {
+            //       shouldValidate: true,
+            //       shouldDirty: true,
+            //     });
+            //   }
+            // }}
             isAnonymous={isAnonymous}
             onChangeAnonymous={(val) =>
               setValue('isAnonymous', val, { shouldDirty: true })

--- a/apps/web/src/features/report/api/post/index.ts
+++ b/apps/web/src/features/report/api/post/index.ts
@@ -1,6 +1,10 @@
 import {
+  type ReportCommentResponseDto,
+  type ReportCommentRequestDto,
   type ReportPostRequestDto,
   type ReportPostResponseDto,
+  type ReportChildCommentRequestDto,
+  type ReportChildCommentResponseDto,
 } from '@/entities/report';
 
 import { API } from '@/shared/api';
@@ -10,7 +14,29 @@ export const reportPost = async ({
   reportReason,
 }: ReportPostRequestDto): Promise<ReportPostResponseDto> => {
   const data = await API.post<ReportPostResponseDto>(
-    `/api/v2/posts/${postId}/reports`,
+    `/api/v2/reports/posts/${postId}`,
+    { reportReason },
+  );
+  return data;
+};
+
+export const reportComment = async ({
+  commentId,
+  reportReason,
+}: ReportCommentRequestDto): Promise<ReportCommentResponseDto> => {
+  const data = await API.post<ReportCommentResponseDto>(
+    `/api/v2/reports/comments/${commentId}`,
+    { reportReason },
+  );
+  return data;
+};
+
+export const reportReply = async ({
+  childCommentId,
+  reportReason,
+}: ReportChildCommentRequestDto): Promise<ReportChildCommentResponseDto> => {
+  const data = await API.post<ReportChildCommentResponseDto>(
+    `/api/v2/reports/child-comments/${childCommentId}`,
     { reportReason },
   );
   return data;

--- a/apps/web/src/features/report/model/mutations/index.ts
+++ b/apps/web/src/features/report/model/mutations/index.ts
@@ -1,1 +1,3 @@
 export * from './useReportPostMutation';
+export * from './useReportCommentMutation';
+export * from './useReportReplyMutation';

--- a/apps/web/src/features/report/model/mutations/useReportCommentMutation.ts
+++ b/apps/web/src/features/report/model/mutations/useReportCommentMutation.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+
+import { toast } from '@/shared/model';
+
+import { reportComment } from '../../api/post';
+
+export const useReportCommentMutation = () => {
+  return useMutation({
+    mutationFn: reportComment,
+
+    onSuccess: () => {
+      toast.success('신고가 접수되었어요');
+    },
+
+    onError: () => {
+      toast.error('댓글 신고에 실패했어요.');
+    },
+  });
+};

--- a/apps/web/src/features/report/model/mutations/useReportReplyMutation.ts
+++ b/apps/web/src/features/report/model/mutations/useReportReplyMutation.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+
+import { toast } from '@/shared/model';
+
+import { reportReply } from '../../api/post';
+
+export const useReportReplyMutation = () => {
+  return useMutation({
+    mutationFn: reportReply,
+
+    onSuccess: () => {
+      toast.success('신고가 접수되었어요');
+    },
+
+    onError: () => {
+      toast.error('답글 신고에 실패했어요.');
+    },
+  });
+};

--- a/apps/web/src/widgets/post/ui/CommentList.tsx
+++ b/apps/web/src/widgets/post/ui/CommentList.tsx
@@ -19,7 +19,7 @@ export const CommentList = ({
   comments,
   onReply,
 }: CommentListProps) => {
-  const isEmpty = countComment === 0;
+  const isEmpty = comments.length === 0;
 
   return (
     <VStack as="section" gap="none" className="flex h-fit flex-1 bg-white pt-5">


### PR DESCRIPTION
# 🚀 Pull Request

## Issue

- Closes #155 

## ✨ Summary

게시글 조회 중 댓글과 답글에 대한 신고, 차단 API 연동 작업을 진행했습니다.

## 📚 Details of Changes

- 댓/답글 신고 API 연동
- 댓/답글 유저 차단 API 연동
- 게시글 투표 트리거 버튼 주석 처리 (API 작업 완료되면 해제 예정)

## 🎯 Key points to review

- 

## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

<img width="885" height="835" alt="image" src="https://github.com/user-attachments/assets/7eac3af2-3a80-4c79-9f79-1b983258cfeb" />

## 📎 Additional Notes

삭제/차단된 유저 프사의 경우 현재는 랜덤 프로필 사진이 노출되고 있습니다.
restricted 프로필 관련 cds PR 머지 후 반영하여 해결할 예정입니다.