### PR TITLE
[FEAT/#173] 소셜 로그인 이후 추가 정보 입력 페이지에서 약관 동의 모달 추가

### DIFF
--- a/apps/web/src/_pages/auth/sign-up/oauth-additional-info/OauthAdditionalInfoPage.tsx
+++ b/apps/web/src/_pages/auth/sign-up/oauth-additional-info/OauthAdditionalInfoPage.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { FormProvider } from 'react-hook-form';
 
+import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 
 import { AuthContainer, OauthAdditionalInfoForm } from '@/widgets/auth';
@@ -14,13 +15,44 @@ import {
   useOauthAdditionalInfoForm,
 } from '@/features/auth';
 
-import { ActionHeader, DesktopOnly, MobileOnly } from '@/shared/ui';
+import type { TermsAgreementRequestDto } from '@/entities/auth';
+
+import { useBreakpoint } from '@/shared/hooks';
+import {
+  ActionHeader,
+  DesktopOnly,
+  MobileOnly,
+  SuspenseView,
+} from '@/shared/ui';
+
+const TermsBottomSheet = dynamic(
+  () => import('@/widgets/auth').then((mod) => mod.TermsBottomSheet),
+  {
+    ssr: false,
+    loading: () => <SuspenseView />,
+  },
+);
+
+const TermsDialog = dynamic(
+  () => import('@/widgets/auth').then((mod) => mod.TermsDialog),
+  {
+    ssr: false,
+    loading: () => <SuspenseView />,
+  },
+);
 
 export const OauthAdditionalInfoPage = () => {
   const router = useRouter();
+  const { isMobileSize } = useBreakpoint();
   const { data } = useGetMeQuery();
-  const { methods, isSubmitEnabled, handlePhoneNumberChange, onSubmit } =
-    useOauthAdditionalInfoForm();
+  const {
+    methods,
+    isSubmitEnabled,
+    handlePhoneNumberChange,
+    setAgreedTermsIds,
+    onSubmit,
+  } = useOauthAdditionalInfoForm();
+  const [termsOpen, setTermsOpen] = useState(false);
 
   useEffect(() => {
     if (!data) return;
@@ -28,6 +60,19 @@ export const OauthAdditionalInfoPage = () => {
       routeAfterSignIn(router, data.onboardingStatus);
     }
   }, [data, router]);
+
+  const handleOpenTerms = () => {
+    setTermsOpen(true);
+  };
+
+  const handleSubmitTerms = ({ termsIds }: TermsAgreementRequestDto) => {
+    setAgreedTermsIds(termsIds);
+  };
+
+  const handleTermsComplete = () => {
+    setTermsOpen(false);
+    methods.handleSubmit(onSubmit)();
+  };
 
   return (
     <FormProvider {...methods}>
@@ -38,7 +83,7 @@ export const OauthAdditionalInfoPage = () => {
       </MobileOnly>
 
       <AuthContainer>
-        <form onSubmit={methods.handleSubmit(onSubmit)}>
+        <form onSubmit={methods.handleSubmit(handleOpenTerms)}>
           <DesktopOnly>
             <ActionHeader className="mb-10 px-0">
               <ActionHeader.BackButton>뒤로</ActionHeader.BackButton>
@@ -50,6 +95,23 @@ export const OauthAdditionalInfoPage = () => {
             onPhoneNumberChange={handlePhoneNumberChange}
           />
         </form>
+
+        {termsOpen && isMobileSize && (
+          <TermsBottomSheet
+            open
+            onOpenChange={setTermsOpen}
+            onComplete={handleTermsComplete}
+            onSubmitTermsAgreement={handleSubmitTerms}
+          />
+        )}
+        {termsOpen && !isMobileSize && (
+          <TermsDialog
+            open
+            onOpenChange={setTermsOpen}
+            onComplete={handleTermsComplete}
+            onSubmitTermsAgreement={handleSubmitTerms}
+          />
+        )}
       </AuthContainer>
     </FormProvider>
   );

--- a/apps/web/src/entities/auth/model/types/types.ts
+++ b/apps/web/src/entities/auth/model/types/types.ts
@@ -164,6 +164,7 @@ export interface SocialLoginAdditionalInfoRequestDto {
   name: string;
   phoneNumber: string;
   nickname: string;
+  agreedTermsIds: string[];
 }
 
 type AcademicStatus =

--- a/apps/web/src/features/auth/model/form/useOauthAdditionalInfoForm.ts
+++ b/apps/web/src/features/auth/model/form/useOauthAdditionalInfoForm.ts
@@ -9,33 +9,43 @@ import { useSocialRegistrationMutation } from '@/features/auth';
 import {
   OAUTH_ADDITIONAL_INFO_FORM_FIELD,
   infoSchema,
-  type InfoFormData,
+  TERMS_FORM_FIELD,
+  termsAgreementSchema,
+  type SocialLoginAdditionalInfoRequestDto,
 } from '@/entities/auth';
 
 import { usePhoneNumberChangeHandler } from '@/shared/hooks';
 
 export const useOauthAdditionalInfoForm = () => {
   const socialRegistrationMutation = useSocialRegistrationMutation();
-  const methods = useForm<InfoFormData>({
-    resolver: zodResolver(infoSchema),
+  const methods = useForm<SocialLoginAdditionalInfoRequestDto>({
+    resolver: zodResolver(infoSchema.and(termsAgreementSchema)),
     mode: 'onBlur',
     defaultValues: {
       name: '',
       phoneNumber: '',
       nickname: '',
+      agreedTermsIds: [],
     },
   });
 
   const isSubmitEnabled = methods.formState.isValid;
 
-  const { handlePhoneNumberChange } = usePhoneNumberChangeHandler<InfoFormData>(
-    {
+  const { handlePhoneNumberChange } =
+    usePhoneNumberChangeHandler<SocialLoginAdditionalInfoRequestDto>({
       setValue: methods.setValue,
       fieldName: OAUTH_ADDITIONAL_INFO_FORM_FIELD.phoneNumber,
-    },
-  );
+    });
 
-  const onSubmit = async (data: InfoFormData) => {
+  const setAgreedTermsIds = (agreedTermsIds: string[]) => {
+    methods.setValue(TERMS_FORM_FIELD.agreedTermsIds, agreedTermsIds, {
+      shouldDirty: true,
+      shouldTouch: true,
+      shouldValidate: true,
+    });
+  };
+
+  const onSubmit = async (data: SocialLoginAdditionalInfoRequestDto) => {
     await socialRegistrationMutation.mutateAsync(data);
   };
 
@@ -43,6 +53,7 @@ export const useOauthAdditionalInfoForm = () => {
     methods,
     isSubmitEnabled,
     handlePhoneNumberChange,
+    setAgreedTermsIds,
     onSubmit,
   };
 };


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #173 


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 소셜 추가정보 플로우에서 약관 동의 모달을 공통으로 사용하고, 별도 약관 동의 API 호출 없이 최종 요청 payload에 약관 동의 정보를 포함하도록 수정했습니다.


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- OAuth additional info 페이지에서 약관 동의 모달 노출 후 `agreedTermsIds`를 추가 정보 입력 요청에 포함하도록 반영
- 소셜 추가정보 등록 API DTO에 `agreedTermsIds` 반영


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- sign-up / oauth additional info 플로우에서 약관 동의 API가 별도로 호출되지 않는지
- 최종 요청 payload에 `agreedTermsIds`가 의도대로 포함되는지


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.

- 변경 파일 기준 eslint 확인


## 📎 Additional Notes
- 약관 동의 모달은 회원가입과 소셜 추가정보 입력에서 화면/선택 수집 용도로만 사용합니다.
