### PR TITLE
[FEAT/#179] 이메일 로그인 데스크톱 소셜 로그인 dto 바뀌는 부분 수정

### DIFF
--- a/apps/web/src/_pages/auth/sign-in/EmailLoginPage.tsx
+++ b/apps/web/src/_pages/auth/sign-in/EmailLoginPage.tsx
@@ -34,7 +34,7 @@ export const EmailLoginPage = () => {
   const signInMutation = useSignInMutation({
     onSuccess: async (res) => {
       await TokenManager.setAccessToken(res.accessToken);
-      await TokenManager.setRefreshToken();
+      await TokenManager.setRefreshToken(res.refreshToken);
 
       routeAfterSignIn(router, res.onboardingStatus);
       void compareFCMToken();

--- a/apps/web/src/_pages/auth/social-login-callback/SocialLoginCallbackPage.tsx
+++ b/apps/web/src/_pages/auth/social-login-callback/SocialLoginCallbackPage.tsx
@@ -38,10 +38,14 @@ export const SocialLoginCallbackPage = () => {
           throw new Error('No RefreshToken');
         }
 
-        const auth = await TokenManager.refreshAuth(refreshToken);
-        await TokenManager.setAccessToken(auth.accessToken);
-        await TokenManager.setRefreshToken(auth.refreshToken);
-        routeAfterSignIn(router, auth.onboardingStatus);
+        const {
+          accessToken,
+          refreshToken: newRefreshToken,
+          onboardingStatus,
+        } = await TokenManager.refreshAuth(refreshToken);
+        await TokenManager.setAccessToken(accessToken);
+        await TokenManager.setRefreshToken(newRefreshToken);
+        routeAfterSignIn(router, onboardingStatus);
       } catch {
         toast.error('잘못된 인증 정보입니다.');
         router.replace('/auth/sign-in');

--- a/apps/web/src/_pages/auth/social-login-callback/SocialLoginCallbackPage.tsx
+++ b/apps/web/src/_pages/auth/social-login-callback/SocialLoginCallbackPage.tsx
@@ -32,9 +32,16 @@ export const SocialLoginCallbackPage = () => {
 
     const handleCallback = async () => {
       try {
+        const refreshToken = searchParams.get('refreshToken');
+
+        if (!refreshToken) {
+          throw new Error('No RefreshToken');
+        }
+
+        await TokenManager.setRefreshToken(refreshToken);
         const auth = await TokenManager.refreshAuth();
         await TokenManager.setAccessToken(auth.accessToken);
-        await TokenManager.setRefreshToken();
+        await TokenManager.setRefreshToken(auth.refreshToken);
         routeAfterSignIn(router, auth.onboardingStatus);
       } catch {
         toast.error('잘못된 인증 정보입니다.');

--- a/apps/web/src/_pages/auth/social-login-callback/SocialLoginCallbackPage.tsx
+++ b/apps/web/src/_pages/auth/social-login-callback/SocialLoginCallbackPage.tsx
@@ -38,8 +38,7 @@ export const SocialLoginCallbackPage = () => {
           throw new Error('No RefreshToken');
         }
 
-        await TokenManager.setRefreshToken(refreshToken);
-        const auth = await TokenManager.refreshAuth();
+        const auth = await TokenManager.refreshAuth(refreshToken);
         await TokenManager.setAccessToken(auth.accessToken);
         await TokenManager.setRefreshToken(auth.refreshToken);
         routeAfterSignIn(router, auth.onboardingStatus);

--- a/apps/web/src/_pages/home/HomePage.tsx
+++ b/apps/web/src/_pages/home/HomePage.tsx
@@ -1,68 +1,34 @@
-'use client';
-
 import { Suspense } from 'react';
 
-import { Skeleton, VStack } from '@causw/cds';
-
-import { CalendarEventListPreview } from '@/widgets/calendar';
 import {
-  CeremonyListPreview,
-  CeremonyRegisterBanner,
-} from '@/widgets/ceremony';
-import {
-  NotificationMobileHeader,
-  // NotificationPopupCard,
-} from '@/widgets/notification';
-import { UserGreetingHeader } from '@/widgets/user';
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from '@tanstack/react-query';
 
-import { QuickMenu } from '@/shared/ui';
+import { HomePageContent } from '@/widgets/home';
 
-//TODO : 해당 페이지 나오면 상세 페이지들 주소 수정
-//TODO : 졸업생 정보
+import { authQueryOptions } from '@/entities/auth';
 
-export function HomePage() {
-  const isAlumni = true;
+import { QUERY_STALE_TIME } from '@/shared/constants';
+import { SuspenseView } from '@/shared/ui';
+
+export async function HomePage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: QUERY_STALE_TIME.LONG,
+      },
+    },
+  });
+
+  queryClient.prefetchQuery(authQueryOptions.me());
 
   return (
-    <VStack className="tablet:gap-8 max-w-desktop tablet:px-8 tablet:pt-12 desktop:gap-6 mx-auto w-full gap-2 px-4 pb-[2.125rem]">
-      {/* Mobile Header */}
-      <div className="tablet:hidden sticky top-0 z-10">
-        <NotificationMobileHeader />
-      </div>
-
-      {/* Desktop Greeting */}
-      <div className="tablet:block hidden">
-        <Suspense fallback={<Skeleton width={400} height={52} />}>
-          <UserGreetingHeader />
-        </Suspense>
-      </div>
-
-      <VStack className="desktop:gap-6 gap-4">
-        {/* TODO : 20260303 주석 처리 : 기획 및 api 변경으로 인해 임시 주석 -> api 수정 후에 다시 노출 (모든 알림 -> 서비스 공지로 수정) */}
-        {/* <NotificationPopupCard /> */}
-        {isAlumni && (
-          <div className="desktop:block hidden">
-            <CeremonyRegisterBanner />
-          </div>
-        )}
-
-        <div className="desktop:grid-cols-2 desktop:gap-x-6 desktop:gap-y-8 grid w-full grid-cols-1 gap-4">
-          {!isAlumni && <QuickMenu />}
-
-          {!isAlumni && (
-            <div className="desktop:block hidden">
-              <CeremonyRegisterBanner />
-            </div>
-          )}
-
-          <CalendarEventListPreview />
-
-          <div className="desktop:hidden">
-            <CeremonyRegisterBanner />
-          </div>
-          <CeremonyListPreview />
-        </div>
-      </VStack>
-    </VStack>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <Suspense fallback={<SuspenseView />}>
+        <HomePageContent />
+      </Suspense>
+    </HydrationBoundary>
   );
 }

--- a/apps/web/src/app/_provider/auth-refresh/AuthRefreshProvider.tsx
+++ b/apps/web/src/app/_provider/auth-refresh/AuthRefreshProvider.tsx
@@ -16,9 +16,10 @@ export function AuthRefreshProvider({ children }: PropsWithChildren) {
       if (!authRefreshed) {
         return;
       }
-
-      await TokenManager.syncTokens();
-      await TokenManager.removeAuthRefreshed();
+      Promise.all([
+        TokenManager.syncTokens(),
+        TokenManager.removeAuthRefreshed(),
+      ]);
     };
 
     void syncRefreshToken();

--- a/apps/web/src/app/_provider/auth-refresh/AuthRefreshProvider.tsx
+++ b/apps/web/src/app/_provider/auth-refresh/AuthRefreshProvider.tsx
@@ -11,12 +11,17 @@ export function AuthRefreshProvider({ children }: PropsWithChildren) {
   const pathname = usePathname();
 
   useEffect(() => {
-    if (!TokenManager.getAuthRefreshed()) {
-      return;
-    }
+    const syncRefreshToken = async () => {
+      const authRefreshed = await TokenManager.getAuthRefreshed();
+      if (!authRefreshed) {
+        return;
+      }
 
-    TokenManager.setRefreshToken();
-    TokenManager.removeAuthRefreshed();
+      await TokenManager.syncTokens();
+      await TokenManager.removeAuthRefreshed();
+    };
+
+    void syncRefreshToken();
   }, [pathname]);
 
   return <>{children}</>;

--- a/apps/web/src/app/auth/layout.tsx
+++ b/apps/web/src/app/auth/layout.tsx
@@ -1,4 +1,5 @@
 import { DesktopOnly, LogoHeader } from '@/shared/ui';
+import { ClearQueryProvider } from '@/shared/ui/provider';
 
 export default function AuthLayout({
   children,
@@ -10,7 +11,7 @@ export default function AuthLayout({
       <DesktopOnly>
         <LogoHeader></LogoHeader>
       </DesktopOnly>
-      {children}
+      <ClearQueryProvider>{children}</ClearQueryProvider>
     </>
   );
 }

--- a/apps/web/src/app/auth/layout.tsx
+++ b/apps/web/src/app/auth/layout.tsx
@@ -1,5 +1,4 @@
-import { DesktopOnly, LogoHeader } from '@/shared/ui';
-import { ClearQueryProvider } from '@/shared/ui/provider';
+import { ClearQueryProvider, DesktopOnly, LogoHeader } from '@/shared/ui';
 
 export default function AuthLayout({
   children,

--- a/apps/web/src/entities/auth/model/types/types.ts
+++ b/apps/web/src/entities/auth/model/types/types.ts
@@ -10,25 +10,9 @@ export interface SignupRequestDto {
   agreedTermsIds: string[];
 }
 
-export interface SignupResponseDto {
-  accessToken: string;
-  refreshToken: string;
-  name: string;
-  email: string;
-  profileImgUrl: string;
-}
-
 export interface SigninRequestDto {
   email: string;
   password: string;
-}
-
-export interface SigninResponseDto {
-  accessToken: string;
-  refreshToken: string;
-  name: string;
-  email: string;
-  profileImgUrl: string;
 }
 
 export type OnboardingStatus =

--- a/apps/web/src/entities/auth/model/types/types.ts
+++ b/apps/web/src/entities/auth/model/types/types.ts
@@ -12,6 +12,7 @@ export interface SignupRequestDto {
 
 export interface SignupResponseDto {
   accessToken: string;
+  refreshToken: string;
   name: string;
   email: string;
   profileImgUrl: string;
@@ -24,6 +25,7 @@ export interface SigninRequestDto {
 
 export interface SigninResponseDto {
   accessToken: string;
+  refreshToken: string;
   name: string;
   email: string;
   profileImgUrl: string;
@@ -126,6 +128,7 @@ type AcademicStatus =
 
 export interface AuthResponseDto {
   accessToken: string;
+  refreshToken: string;
   name: string;
   email: string;
   profileImage: {
@@ -134,14 +137,6 @@ export interface AuthResponseDto {
   };
   onboardingStatus: OnboardingStatus;
   academicStatus: AcademicStatus;
-}
-
-/** SigninResponseDto와 동일한 구조를 공유하되, 추후 필드 확장을 위해 분리 */
-export interface GoogleLoginResponseDto {
-  accessToken: string;
-  name: string;
-  email: string;
-  profileImgUrl: string;
 }
 
 export interface FindEmailRequestDto {

--- a/apps/web/src/entities/auth/model/types/types.ts
+++ b/apps/web/src/entities/auth/model/types/types.ts
@@ -100,52 +100,6 @@ export interface TermsAgreementRequestDto {
   termsIds: string[];
 }
 
-export interface KakaoLoginRequestDto {
-  /** 카카오 OAuth 인가 코드 */
-  code: string;
-}
-
-export interface KakaoNativeLoginRequestDto {
-  /** Native SDK에서 받은 카카오 액세스 토큰 */
-  accessToken: string;
-}
-
-/** SigninResponseDto와 동일한 구조를 공유하되, 추후 필드 확장을 위해 분리 */
-export interface KakaoLoginResponseDto {
-  accessToken: string;
-  name: string;
-  email: string;
-  profileImgUrl: string;
-}
-
-export interface AppleLoginRequestDto {
-  /** Apple OAuth 인가 코드 */
-  code: string;
-}
-
-export interface AppleNativeLoginRequestDto {
-  /** Native SDK에서 받은 Apple 액세스 토큰 */
-  accessToken: string;
-}
-
-/** SigninResponseDto와 동일한 구조를 공유하되, 추후 필드 확장을 위해 분리 */
-export interface AppleLoginResponseDto {
-  accessToken: string;
-  name: string;
-  email: string;
-  profileImgUrl: string;
-}
-
-export interface GoogleLoginRequestDto {
-  /** Google OAuth 인가 코드 */
-  code: string;
-}
-
-export interface GoogleNativeLoginRequestDto {
-  /** Native SDK에서 받은 Google 액세스 토큰 */
-  accessToken: string;
-}
-
 export type NativeSocialLoginProvider = 'kakao' | 'apple' | 'google';
 
 export interface NativeSocialLoginRequestDto {

--- a/apps/web/src/entities/ceremony/ui/CeremonyListItem.tsx
+++ b/apps/web/src/entities/ceremony/ui/CeremonyListItem.tsx
@@ -44,31 +44,48 @@ const formatDateRange = (
 export const CeremonyListItem = ({ item, onClick }: CeremonyListItemProps) => {
   const { title, category, type, startDate, endDate, startTime, endTime } =
     item;
+  const TITLE_INTERACTIVE_TEXT_STYLES =
+    'transition-colors group-hover:text-gray-400 group-active:text-gray-400';
+  const DESCRIPTION_INTERACTIVE_TEXT_STYLES =
+    'transition-colors group-hover:text-gray-300 group-active:text-gray-300';
+  const CHEVRON_INTERACTIVE_STYLES =
+    'transition-colors fill-gray-300 group-hover:fill-gray-300 group-active:fill-gray-300';
 
   return (
     <button
       type="button"
       onClick={onClick}
-      className="flex w-full cursor-pointer items-center gap-5 rounded-xl bg-white p-4"
+      className="group flex w-full cursor-pointer items-center gap-5 rounded-xl bg-white p-4"
     >
       <div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-gray-100">
         {getCeremonyIcon(category)}
       </div>
 
       <div className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
-        <span className="typo-subtitle-16-bold w-full truncate text-left text-gray-700">
+        <span
+          className={`typo-subtitle-16-bold w-full truncate text-left text-gray-700 ${TITLE_INTERACTIVE_TEXT_STYLES}`}
+        >
           {title}
         </span>
         <div className="flex items-center gap-2">
-          <span className="typo-body-14-regular text-gray-400">
+          <span
+            className={`typo-body-14-regular text-gray-400 ${DESCRIPTION_INTERACTIVE_TEXT_STYLES}`}
+          >
             {formatDateRange(startDate, endDate, startTime, endTime)}
           </span>
           <span className="h-2 w-px bg-gray-200" />
-          <span className="typo-body-14-regular text-gray-400">{type}</span>
+          <span
+            className={`typo-body-14-regular text-gray-400 ${DESCRIPTION_INTERACTIVE_TEXT_STYLES}`}
+          >
+            {type}
+          </span>
         </div>
       </div>
 
-      <ChevronRight size={14} className="shrink-0 fill-gray-300" />
+      <ChevronRight
+        size={14}
+        className={`shrink-0 ${CHEVRON_INTERACTIVE_STYLES}`}
+      />
     </button>
   );
 };

--- a/apps/web/src/entities/ceremony/ui/CeremonyListItem.tsx
+++ b/apps/web/src/entities/ceremony/ui/CeremonyListItem.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight } from '@causw/cds';
+import { ChevronRight, mergeStyles } from '@causw/cds';
 
 import { getCeremonyIcon } from '../config';
 import type { CeremonyItem } from '../model';
@@ -63,19 +63,28 @@ export const CeremonyListItem = ({ item, onClick }: CeremonyListItemProps) => {
 
       <div className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
         <span
-          className={`typo-subtitle-16-bold w-full truncate text-left text-gray-700 ${TITLE_INTERACTIVE_TEXT_STYLES}`}
+          className={mergeStyles(
+            'typo-subtitle-16-bold w-full truncate text-left text-gray-700',
+            TITLE_INTERACTIVE_TEXT_STYLES,
+          )}
         >
           {title}
         </span>
         <div className="flex items-center gap-2">
           <span
-            className={`typo-body-14-regular text-gray-400 ${DESCRIPTION_INTERACTIVE_TEXT_STYLES}`}
+            className={mergeStyles(
+              'typo-body-14-regular text-gray-400',
+              DESCRIPTION_INTERACTIVE_TEXT_STYLES,
+            )}
           >
             {formatDateRange(startDate, endDate, startTime, endTime)}
           </span>
           <span className="h-2 w-px bg-gray-200" />
           <span
-            className={`typo-body-14-regular text-gray-400 ${DESCRIPTION_INTERACTIVE_TEXT_STYLES}`}
+            className={mergeStyles(
+              'typo-body-14-regular text-gray-400',
+              DESCRIPTION_INTERACTIVE_TEXT_STYLES,
+            )}
           >
             {type}
           </span>
@@ -84,7 +93,7 @@ export const CeremonyListItem = ({ item, onClick }: CeremonyListItemProps) => {
 
       <ChevronRight
         size={14}
-        className={`shrink-0 ${CHEVRON_INTERACTIVE_STYLES}`}
+        className={mergeStyles('shrink-0', CHEVRON_INTERACTIVE_STYLES)}
       />
     </button>
   );

--- a/apps/web/src/features/auth/api/post/session.ts
+++ b/apps/web/src/features/auth/api/post/session.ts
@@ -20,6 +20,7 @@ import type {
 
 import { API } from '@/shared/api';
 import { AUTH_API_PREFIX } from '@/shared/constants';
+import { TokenManager } from '@/shared/storage';
 
 export const signup = async (data: SignupRequestDto) => {
   return API.post<SignupResponseDto>(`${AUTH_API_PREFIX}/signup`, data);
@@ -30,7 +31,13 @@ export const signin = async (data: SigninRequestDto) => {
 };
 
 export const signout = async (data: SignoutRequestDto) => {
-  return API.post<SignoutResponseDto>(`${AUTH_API_PREFIX}/logout`, data);
+  const refreshToken = await TokenManager.getRefreshToken();
+
+  return API.post<SignoutResponseDto>(`${AUTH_API_PREFIX}/logout`, data, {
+    headers: {
+      'Refresh-Authorization': `Bearer ${refreshToken}`,
+    },
+  });
 };
 
 export const sendEmailVerificationCode = async (

--- a/apps/web/src/features/auth/api/post/session.ts
+++ b/apps/web/src/features/auth/api/post/session.ts
@@ -1,5 +1,4 @@
 import type {
-  SignupResponseDto,
   SignoutResponseDto,
   SignupRequestDto,
   SigninRequestDto,
@@ -23,7 +22,7 @@ import { AUTH_API_PREFIX } from '@/shared/constants';
 import { TokenManager } from '@/shared/storage';
 
 export const signup = async (data: SignupRequestDto) => {
-  return API.post<SignupResponseDto>(`${AUTH_API_PREFIX}/signup`, data);
+  return API.post<AuthResponseDto>(`${AUTH_API_PREFIX}/signup`, data);
 };
 
 export const signin = async (data: SigninRequestDto) => {

--- a/apps/web/src/features/auth/mock/patch.ts
+++ b/apps/web/src/features/auth/mock/patch.ts
@@ -15,6 +15,7 @@ export const patchHandler = [
         message: '요청 처리 성공',
         data: {
           accessToken: 'test',
+          refreshToken: 'refresh-test',
           name: 'test',
           email: 'test',
           profileImage: {

--- a/apps/web/src/features/auth/mock/post.ts
+++ b/apps/web/src/features/auth/mock/post.ts
@@ -1,17 +1,12 @@
 import { HttpResponse, passthrough } from 'msw';
 
-import {
-  type AuthResponseDto,
-  type SigninResponseDto,
-  type SignoutResponseDto,
-  type SignupResponseDto,
-} from '@/entities/auth';
+import { type AuthResponseDto, type SignoutResponseDto } from '@/entities/auth';
 
 import { AUTH_API_PREFIX } from '@/shared/constants';
 import { mswHttp } from '@/shared/lib';
 
 export const postHandler = [
-  mswHttp.post<SignupResponseDto>(`${AUTH_API_PREFIX}/signup`, () => {
+  mswHttp.post<AuthResponseDto>(`${AUTH_API_PREFIX}/signup`, () => {
     return passthrough();
     return HttpResponse.json(
       {
@@ -22,7 +17,12 @@ export const postHandler = [
           refreshToken: 'refresh-1234567890',
           name: 'John Doe',
           email: 'john.doe@example.com',
-          profileImgUrl: 'https://picsum.photos/seed/profile1/200/200',
+          profileImage: {
+            profileImageType: 'CUSTOM',
+            profileImageUrl: 'https://picsum.photos/seed/profile1/200/200',
+          },
+          onboardingStatus: 'GUEST',
+          academicStatus: 'UNDETERMINED',
         },
       },
       {
@@ -30,7 +30,7 @@ export const postHandler = [
       },
     );
   }),
-  mswHttp.post<SigninResponseDto>(`${AUTH_API_PREFIX}/login`, () => {
+  mswHttp.post<AuthResponseDto>(`${AUTH_API_PREFIX}/login`, () => {
     return passthrough();
     return HttpResponse.json(
       {
@@ -41,7 +41,12 @@ export const postHandler = [
           refreshToken: 'refresh-1234567890',
           name: 'John Doe',
           email: 'john.doe@example.com',
-          profileImgUrl: 'https://picsum.photos/seed/profile1/200/200',
+          profileImage: {
+            profileImageType: 'CUSTOM',
+            profileImageUrl: 'https://picsum.photos/seed/profile1/200/200',
+          },
+          onboardingStatus: 'GUEST',
+          academicStatus: 'UNDETERMINED',
         },
       },
       { status: 201 },

--- a/apps/web/src/features/auth/mock/post.ts
+++ b/apps/web/src/features/auth/mock/post.ts
@@ -19,6 +19,7 @@ export const postHandler = [
         message: 'Signup successful',
         data: {
           accessToken: '1234567890',
+          refreshToken: 'refresh-1234567890',
           name: 'John Doe',
           email: 'john.doe@example.com',
           profileImgUrl: 'https://picsum.photos/seed/profile1/200/200',
@@ -37,6 +38,7 @@ export const postHandler = [
         message: 'Login successful',
         data: {
           accessToken: '1234567890',
+          refreshToken: 'refresh-1234567890',
           name: 'John Doe',
           email: 'john.doe@example.com',
           profileImgUrl: 'https://picsum.photos/seed/profile1/200/200',
@@ -52,6 +54,7 @@ export const postHandler = [
         message: 'Native social login successful',
         data: {
           accessToken: '1234567890',
+          refreshToken: 'refresh-1234567890',
           name: '홍길동',
           email: 'hong.gildong@example.com',
           profileImage: {

--- a/apps/web/src/features/auth/model/commands/useLogout.ts
+++ b/apps/web/src/features/auth/model/commands/useLogout.ts
@@ -2,8 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 
-import { useQueryClient } from '@tanstack/react-query';
-
+import { CLEAR_QUERY_PARAM, CLEAR_QUERY_PARAM_VALUE } from '@/shared/constants';
 import { TokenManager, getNativeFCM, removeNativeFCM } from '@/shared/storage';
 import { isMobile } from '@/shared/utils';
 
@@ -11,7 +10,6 @@ import { useSignOutMutation } from '../mutations';
 
 export const useLogout = () => {
   const router = useRouter();
-  const queryClient = useQueryClient();
   const signOutMutation = useSignOutMutation();
 
   return async () => {
@@ -24,7 +22,8 @@ export const useLogout = () => {
     if (isMobile) {
       await removeNativeFCM();
     }
-    queryClient.clear();
-    router.push('/auth/sign-in');
+    await router.replace(
+      `/auth/sign-in?${CLEAR_QUERY_PARAM}=${CLEAR_QUERY_PARAM_VALUE}`,
+    );
   };
 };

--- a/apps/web/src/features/auth/model/mutations/useNativeSocialLoginFlowMutation.ts
+++ b/apps/web/src/features/auth/model/mutations/useNativeSocialLoginFlowMutation.ts
@@ -54,7 +54,7 @@ export const useNativeSocialLoginFlowMutation = (
     >['onSuccess']
   > = async (data) => {
     await TokenManager.setAccessToken(data.accessToken);
-    await TokenManager.setRefreshToken();
+    await TokenManager.setRefreshToken(data.refreshToken);
     routeAfterSignIn(router, data.onboardingStatus);
     toast.success('로그인되었습니다.');
   };

--- a/apps/web/src/features/auth/model/mutations/useSessionMutations.ts
+++ b/apps/web/src/features/auth/model/mutations/useSessionMutations.ts
@@ -6,7 +6,6 @@ import type {
   SigninRequestDto,
   SignupRequestDto,
   SignoutRequestDto,
-  SignupResponseDto,
   SignoutResponseDto,
   AuthResponseDto,
 } from '@/entities/auth';
@@ -15,7 +14,7 @@ import { toast } from '@/shared/model';
 import { extractErrorMessage } from '@/shared/utils';
 
 type SignUpMutationOptions = Omit<
-  UseMutationOptions<SignupResponseDto, Error, SignupRequestDto>,
+  UseMutationOptions<AuthResponseDto, Error, SignupRequestDto>,
   'mutationFn' | 'onMutate' | 'onSuccess' | 'onError'
 >;
 

--- a/apps/web/src/features/auth/model/mutations/useSocialRegistrationMutation.ts
+++ b/apps/web/src/features/auth/model/mutations/useSocialRegistrationMutation.ts
@@ -12,6 +12,7 @@ import type {
 } from '@/entities/auth';
 
 import { toast } from '@/shared/model';
+import { TokenManager } from '@/shared/storage';
 import { extractErrorMessage } from '@/shared/utils';
 
 import { routeAfterSignIn } from '../../lib';
@@ -35,7 +36,9 @@ export const useSocialRegistrationMutation = (
     onMutate: () => {
       toast.loading('추가 정보를 저장하고 있어요...');
     },
-    onSuccess: (data: AuthResponseDto) => {
+    onSuccess: async (data: AuthResponseDto) => {
+      await TokenManager.setAccessToken(data.accessToken);
+      await TokenManager.setRefreshToken(data.refreshToken);
       toast.success('추가 정보 입력이 완료되었습니다.');
       routeAfterSignIn(router, data.onboardingStatus);
     },

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -10,6 +10,10 @@ import {
 import { TokenManager } from './shared/storage';
 import { isAuthRoute, shouldRefreshAccessToken } from './shared/utils/auth';
 
+export const config = {
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico|.*\\..*).*)'],
+};
+
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,17 +1,28 @@
 import { NextResponse, userAgent } from 'next/server';
 import type { NextRequest } from 'next/server';
 
+import {
+  STORAGE_ACCESS_KEY,
+  STORAGE_REFRESH_KEY,
+  STORAGE_AUTH_REFRESHED_KEY,
+  AUTH_REFRESHED_STORAGE_VALUE,
+} from './shared/config';
 import { TokenManager } from './shared/storage';
+import { isAuthRoute, shouldRefreshAccessToken } from './shared/utils/auth';
 
 export async function proxy(request: NextRequest) {
-  if (request.nextUrl.pathname === '/') {
+  const { pathname } = request.nextUrl;
+
+  if (pathname === '/') {
     return NextResponse.redirect(new URL('/auth/sign-in', request.url));
   }
 
-  // TODO: 실제 경로 맞춰서 세분화
-  const privateRoutes = ['/home', '/feed', '/contacts', '/user'];
-  const accessToken = await TokenManager.getAccessToken();
-  const refreshToken = await TokenManager.getRefreshToken();
+  if (isAuthRoute(pathname)) {
+    return NextResponse.next();
+  }
+
+  const accessToken = request.cookies.get(STORAGE_ACCESS_KEY)?.value ?? '';
+  const refreshToken = request.cookies.get(STORAGE_REFRESH_KEY)?.value ?? '';
 
   const { device } = userAgent(request);
 
@@ -20,12 +31,24 @@ export async function proxy(request: NextRequest) {
     return NextResponse.next();
   }
   if (!accessToken && !refreshToken) {
-    if (
-      privateRoutes.some((route) => request.nextUrl.pathname.startsWith(route))
-    ) {
+    return NextResponse.redirect(new URL('/auth/sign-in', request.url));
+  }
+
+  if (refreshToken && (!accessToken || shouldRefreshAccessToken(accessToken))) {
+    try {
+      const refreshedAuth = await TokenManager.refreshAuth(refreshToken);
+
+      const response = NextResponse.next();
+      response.cookies.set(STORAGE_ACCESS_KEY, refreshedAuth.accessToken);
+      response.cookies.set(STORAGE_REFRESH_KEY, refreshedAuth.refreshToken);
+      response.cookies.set(
+        STORAGE_AUTH_REFRESHED_KEY,
+        AUTH_REFRESHED_STORAGE_VALUE,
+      );
+      return response;
+    } catch {
       return NextResponse.redirect(new URL('/auth/sign-in', request.url));
     }
-    return NextResponse.next();
   }
 
   return NextResponse.next();

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -8,7 +8,7 @@ import {
   AUTH_REFRESHED_STORAGE_VALUE,
 } from './shared/config';
 import { TokenManager } from './shared/storage';
-import { isAuthRoute, shouldRefreshAccessToken } from './shared/utils/auth';
+import { isAuthRoute, shouldRefreshAccessToken } from './shared/utils';
 
 export const config = {
   matcher: ['/((?!api|_next/static|_next/image|favicon.ico|.*\\..*).*)'],

--- a/apps/web/src/shared/api/interceptors/request/requestInterceptor.ts
+++ b/apps/web/src/shared/api/interceptors/request/requestInterceptor.ts
@@ -1,7 +1,6 @@
 import { useAuthStore, AuthError } from '@/shared/model';
 import { TokenManager } from '@/shared/storage';
-import { isServer } from '@/shared/utils';
-import { isPublicEndpoint } from '@/shared/utils/auth';
+import { isPublicEndpoint, isServer } from '@/shared/utils';
 
 import { type BaseApiClient } from '../../instances';
 

--- a/apps/web/src/shared/api/interceptors/response/responseInterceptor.ts
+++ b/apps/web/src/shared/api/interceptors/response/responseInterceptor.ts
@@ -3,6 +3,7 @@ import { reportApiError } from '@causw/logger';
 
 import { useAuthStore, AuthError } from '@/shared/model';
 import { TokenManager } from '@/shared/storage';
+import { isServer } from '@/shared/utils';
 import { isPublicEndpoint } from '@/shared/utils/auth';
 import {
   isAccessTokenError,
@@ -39,6 +40,10 @@ export const setResponseInterceptors = (apiWrapper: BaseApiClient) => {
 
       // Access Token 만료 시 + 이전 에러코드 값 포함
       if (shouldHandleAccessTokenRefresh) {
+        if (isServer) {
+          throw error;
+        }
+
         if (apiWrapper.getIsRefreshing()) {
           return new Promise((resolve, reject) => {
             apiWrapper.addToRefreshQueue({
@@ -63,11 +68,11 @@ export const setResponseInterceptors = (apiWrapper: BaseApiClient) => {
         try {
           apiWrapper.setIsRefreshing(true);
 
-          const { accessToken: newAccessToken } =
+          const { accessToken: newAccessToken, refreshToken: newRefreshToken } =
             await TokenManager.refreshAuth();
 
           await TokenManager.setAccessToken(newAccessToken);
-          await TokenManager.setRefreshToken();
+          await TokenManager.setRefreshToken(newRefreshToken);
           await TokenManager.setAuthRefreshed();
 
           apiWrapper.processRefreshQueue(newAccessToken);

--- a/apps/web/src/shared/api/interceptors/response/responseInterceptor.ts
+++ b/apps/web/src/shared/api/interceptors/response/responseInterceptor.ts
@@ -3,12 +3,12 @@ import { reportApiError } from '@causw/logger';
 
 import { useAuthStore, AuthError } from '@/shared/model';
 import { TokenManager } from '@/shared/storage';
-import { isServer } from '@/shared/utils';
-import { isPublicEndpoint } from '@/shared/utils/auth';
 import {
   isAccessTokenError,
+  isPublicEndpoint,
+  isServer,
   parseCustomErrorCode,
-} from '@/shared/utils/auth/errorHandler';
+} from '@/shared/utils';
 
 import { type BaseApiClient } from '../../instances';
 

--- a/apps/web/src/shared/api/interceptors/response/responseInterceptor.ts
+++ b/apps/web/src/shared/api/interceptors/response/responseInterceptor.ts
@@ -68,12 +68,12 @@ export const setResponseInterceptors = (apiWrapper: BaseApiClient) => {
         try {
           apiWrapper.setIsRefreshing(true);
 
+          const refreshToken = await TokenManager.getRefreshToken();
           const { accessToken: newAccessToken, refreshToken: newRefreshToken } =
-            await TokenManager.refreshAuth();
+            await TokenManager.refreshAuth(refreshToken);
 
           await TokenManager.setAccessToken(newAccessToken);
           await TokenManager.setRefreshToken(newRefreshToken);
-          await TokenManager.setAuthRefreshed();
 
           apiWrapper.processRefreshQueue(newAccessToken);
 

--- a/apps/web/src/shared/constants/auth/queryParams.ts
+++ b/apps/web/src/shared/constants/auth/queryParams.ts
@@ -1,0 +1,2 @@
+export const CLEAR_QUERY_PARAM = 'clearQuery';
+export const CLEAR_QUERY_PARAM_VALUE = '1';

--- a/apps/web/src/shared/constants/index.ts
+++ b/apps/web/src/shared/constants/index.ts
@@ -6,6 +6,7 @@ export * from './copy';
 export * from './routes';
 export * from './quick-menu';
 export * from './auth/publicEndpoints';
+export * from './auth/queryParams';
 export * from './form';
 export * from './urls';
 export * from './contact';

--- a/apps/web/src/shared/storage/auth/token-manager.ts
+++ b/apps/web/src/shared/storage/auth/token-manager.ts
@@ -36,9 +36,7 @@ import {
 
 export class TokenManager {
   // Access Token 재발급
-  static async refreshAuth(): Promise<AuthResponseDto> {
-    const refreshToken = await this.getRefreshToken();
-
+  static async refreshAuth(refreshToken: string): Promise<AuthResponseDto> {
     const response = await fetch(`${BASE_URL}${AUTH_API_PREFIX}/refresh`, {
       method: 'POST',
       headers: {
@@ -115,14 +113,13 @@ export class TokenManager {
     }
   }
 
-  static async syncRefreshToken(): Promise<void> {
+  static async syncTokens(): Promise<void> {
     if (isMobile) {
       const refreshToken = getClientRTK();
+      const accessToken = getClientATK();
 
-      if (!refreshToken) {
-        return;
-      }
       await setNativeRTK(refreshToken);
+      await setNativeATK(accessToken);
     }
   }
 

--- a/apps/web/src/shared/storage/auth/token-manager.ts
+++ b/apps/web/src/shared/storage/auth/token-manager.ts
@@ -14,6 +14,7 @@ import {
   removeClientAuthRefreshed,
   removeClientRTK,
   setClientATK,
+  setClientRTK,
 } from './auth-storage';
 import {
   getNativeATK,
@@ -30,18 +31,21 @@ import {
   removeServerRTK,
   setServerAuthRefreshed,
   setServerATK,
+  setServerRTK,
 } from './auth-storage.server';
 
 export class TokenManager {
   // Access Token 재발급
   static async refreshAuth(): Promise<AuthResponseDto> {
+    const refreshToken = await this.getRefreshToken();
+
     const response = await fetch(`${BASE_URL}${AUTH_API_PREFIX}/refresh`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer any-token`,
+        Authorization: `Bearer t`,
+        'Refresh-Authorization': `Bearer ${refreshToken}`,
       },
-      credentials: 'include',
     });
 
     const data: DefaultResponseField<AuthResponseDto> = await response.json();
@@ -66,11 +70,12 @@ export class TokenManager {
 
   static async setAccessToken(token: string): Promise<void> {
     if (isServer) {
-      return await setServerATK(token);
+      await setServerATK(token);
     } else if (isMobile) {
-      return await setNativeATK(token);
+      await setNativeATK(token);
+      setClientATK(token);
     } else {
-      return setClientATK(token);
+      setClientATK(token);
     }
   }
 
@@ -79,6 +84,7 @@ export class TokenManager {
       await removeServerATK();
     } else if (isMobile) {
       await removeNativeATK();
+      removeClientATK();
     } else {
       removeClientATK();
     }
@@ -98,7 +104,18 @@ export class TokenManager {
   /**
    * @description 모바일 환경에서는 쿠키가 유실될 수 있기 때문에(백그라운드 종료) 서버에서 세팅해준 refresh_token을 security Storage로 옮기는 작업을 합니다.
    */
-  static async setRefreshToken(): Promise<void> {
+  static async setRefreshToken(token: string): Promise<void> {
+    if (isServer) {
+      await setServerRTK(token);
+    } else if (isMobile) {
+      await setNativeRTK(token);
+      setClientRTK(token);
+    } else {
+      setClientRTK(token);
+    }
+  }
+
+  static async syncRefreshToken(): Promise<void> {
     if (isMobile) {
       const refreshToken = getClientRTK();
 
@@ -114,6 +131,7 @@ export class TokenManager {
       await removeServerRTK();
     } else if (isMobile) {
       await removeNativeRTK();
+      removeClientRTK();
     } else {
       removeClientRTK();
     }

--- a/apps/web/src/shared/ui/EventCard.tsx
+++ b/apps/web/src/shared/ui/EventCard.tsx
@@ -30,6 +30,13 @@ export function EventCard({
   className,
   rightElement,
 }: EventCardProps) {
+  const TITLE_INTERACTIVE_TEXT_STYLES =
+    'transition-colors group-hover:text-gray-400 group-active:text-gray-400';
+  const DESCRIPTION_INTERACTIVE_TEXT_STYLES =
+    'transition-colors group-hover:text-gray-300 group-active:text-gray-300';
+  const CHEVRON_INTERACTIVE_STYLES =
+    'transition-colors fill-gray-400 group-hover:fill-gray-300 group-active:fill-gray-300';
+
   const CardContent = (
     <HStack
       className={mergeStyles(
@@ -48,14 +55,26 @@ export function EventCard({
         </div>
 
         <VStack className={'flex-1 justify-center gap-0 overflow-hidden'}>
-          <Text typography="subtitle-16-bold" className="truncate">
+          <Text
+            typography="subtitle-16-bold"
+            className={mergeStyles('truncate', TITLE_INTERACTIVE_TEXT_STYLES)}
+          >
             {title}
           </Text>
-          <HStack className="items-center gap-1 text-sm text-gray-400">
+          <HStack
+            className={mergeStyles(
+              'items-center gap-1 text-sm text-gray-400',
+              DESCRIPTION_INTERACTIVE_TEXT_STYLES,
+            )}
+          >
             {descriptions.map((desc, idx) => (
               <React.Fragment key={idx}>
                 {typeof desc === 'string' ? (
-                  <Text typography="body-14-regular" textColor="gray-400">
+                  <Text
+                    typography="body-14-regular"
+                    textColor="gray-400"
+                    className={DESCRIPTION_INTERACTIVE_TEXT_STYLES}
+                  >
                     {desc}
                   </Text>
                 ) : (
@@ -75,7 +94,9 @@ export function EventCard({
       <div className="flex shrink-0 items-center justify-center">
         {rightElement
           ? rightElement
-          : link && <ChevronRight size={14} className="text-gray-400" />}
+          : link && (
+              <ChevronRight size={14} className={CHEVRON_INTERACTIVE_STYLES} />
+            )}
       </div>
     </HStack>
   );
@@ -83,7 +104,7 @@ export function EventCard({
   if (!link) return CardContent;
 
   return (
-    <Link href={link} className="w-full cursor-pointer">
+    <Link href={link} className="group w-full cursor-pointer">
       {CardContent}
     </Link>
   );

--- a/apps/web/src/shared/ui/QuickMenu.tsx
+++ b/apps/web/src/shared/ui/QuickMenu.tsx
@@ -7,20 +7,28 @@ import { HStack, Separator, Text } from '@causw/cds';
 import { QUICK_MENU_ITEMS } from '@/shared/constants';
 
 export function QuickMenu() {
+  const BUTTON_HOVER_STYLES = 'group cursor-pointer';
+  const BUTTON_TEXT_HOVER_STYLES =
+    'group-hover:text-gray-500 group-active:text-gray-500';
   return (
-    <HStack className="w-full items-center justify-around rounded-2xl bg-white px-8 py-5">
+    <HStack className="w-full items-center justify-center gap-5 rounded-xl bg-white px-8 py-5">
       {QUICK_MENU_ITEMS.map((item, index) => (
         <Fragment key={item.label}>
-          <Link href={item.href} className="flex flex-col items-center gap-2">
+          <Link
+            href={item.href}
+            className={`flex flex-col items-center gap-2 ${BUTTON_HOVER_STYLES}`}
+          >
             {item.icon}
-            <Text typography="body-14-medium">{item.label}</Text>
+            <Text
+              typography="body-14-medium"
+              className={BUTTON_TEXT_HOVER_STYLES}
+            >
+              {item.label}
+            </Text>
           </Link>
 
           {index !== QUICK_MENU_ITEMS.length - 1 && (
-            <Separator
-              className="h-6 shrink-0 self-center"
-              orientation="vertical"
-            />
+            <Separator className="mx-0 h-6 shrink-0" orientation="vertical" />
           )}
         </Fragment>
       ))}

--- a/apps/web/src/shared/ui/provider/clear-query/ClearQueryProvider.tsx
+++ b/apps/web/src/shared/ui/provider/clear-query/ClearQueryProvider.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect } from 'react';
+import type { PropsWithChildren } from 'react';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+import { useQueryClient } from '@tanstack/react-query';
+
+import { CLEAR_QUERY_PARAM, CLEAR_QUERY_PARAM_VALUE } from '@/shared/constants';
+
+export const ClearQueryProvider = ({ children }: PropsWithChildren) => {
+  const queryClient = useQueryClient();
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const shouldClearQuery =
+    searchParams.get(CLEAR_QUERY_PARAM) === CLEAR_QUERY_PARAM_VALUE;
+
+  useEffect(() => {
+    if (!shouldClearQuery) return;
+
+    queryClient.clear();
+
+    const nextSearchParams = new URLSearchParams(searchParams.toString());
+    nextSearchParams.delete(CLEAR_QUERY_PARAM);
+
+    const nextSearch = nextSearchParams.toString();
+    router.replace(nextSearch ? `${pathname}?${nextSearch}` : pathname);
+  }, [pathname, queryClient, router, searchParams, shouldClearQuery]);
+
+  return <>{children}</>;
+};

--- a/apps/web/src/shared/ui/provider/clear-query/index.ts
+++ b/apps/web/src/shared/ui/provider/clear-query/index.ts
@@ -1,0 +1,1 @@
+export { ClearQueryProvider } from './ClearQueryProvider';

--- a/apps/web/src/shared/ui/provider/index.ts
+++ b/apps/web/src/shared/ui/provider/index.ts
@@ -2,5 +2,6 @@ export {
   QueryErrorBoundary,
   QueryProviderWithDevtools,
 } from './tanstack-query';
+export { ClearQueryProvider } from './clear-query';
 export { HydrationSuspense } from './suspense/HydrationSuspense';
 export { Toaster } from './toast';

--- a/apps/web/src/shared/utils/auth/index.ts
+++ b/apps/web/src/shared/utils/auth/index.ts
@@ -1,3 +1,8 @@
 export { isPublicEndpoint } from './isPublicEndpoint';
 export { shouldRefreshAccessToken } from './jwt';
 export { isAuthRoute } from './proxyRoutes';
+export {
+  isAccessTokenError,
+  isRefreshTokenError,
+  parseCustomErrorCode,
+} from './errorHandler';

--- a/apps/web/src/shared/utils/auth/index.ts
+++ b/apps/web/src/shared/utils/auth/index.ts
@@ -1,1 +1,3 @@
 export { isPublicEndpoint } from './isPublicEndpoint';
+export { shouldRefreshAccessToken } from './jwt';
+export { isAuthRoute } from './proxyRoutes';

--- a/apps/web/src/shared/utils/auth/jwt.ts
+++ b/apps/web/src/shared/utils/auth/jwt.ts
@@ -1,0 +1,34 @@
+const TOKEN_REFRESH_THRESHOLD_SECONDS = 60;
+
+export const getJwtExp = (token: string): number | null => {
+  const [, payload] = token.split('.');
+
+  if (!payload) {
+    return null;
+  }
+
+  try {
+    const normalizedPayload = payload
+      .replace(/-/g, '+')
+      .replace(/_/g, '/')
+      .padEnd(Math.ceil(payload.length / 4) * 4, '=');
+    const parsedPayload = JSON.parse(atob(normalizedPayload)) as {
+      exp?: unknown;
+    };
+
+    return typeof parsedPayload.exp === 'number' ? parsedPayload.exp : null;
+  } catch {
+    return null;
+  }
+};
+
+export const shouldRefreshAccessToken = (accessToken: string): boolean => {
+  const expiresAt = getJwtExp(accessToken);
+
+  if (!expiresAt) {
+    return true;
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  return expiresAt - now <= TOKEN_REFRESH_THRESHOLD_SECONDS;
+};

--- a/apps/web/src/shared/utils/auth/proxyRoutes.ts
+++ b/apps/web/src/shared/utils/auth/proxyRoutes.ts
@@ -1,0 +1,3 @@
+export const isAuthRoute = (pathname: string): boolean => {
+  return pathname.startsWith('/auth');
+};

--- a/apps/web/src/shared/utils/index.ts
+++ b/apps/web/src/shared/utils/index.ts
@@ -1,4 +1,5 @@
 ﻿export * from './storage';
 export * from './api';
 export * from './env';
+export * from './auth';
 export { getScrollContainer } from './getScrollContainer';

--- a/apps/web/src/widgets/home/index.ts
+++ b/apps/web/src/widgets/home/index.ts
@@ -1,0 +1,1 @@
+export * from './ui/home-page-content';

--- a/apps/web/src/widgets/home/ui/home-page-content/HomePageContent.tsx
+++ b/apps/web/src/widgets/home/ui/home-page-content/HomePageContent.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { Suspense } from 'react';
+
+import { Skeleton, VStack } from '@causw/cds';
+
+import { CalendarEventListPreview } from '@/widgets/calendar';
+import {
+  CeremonyListPreview,
+  CeremonyRegisterBanner,
+} from '@/widgets/ceremony';
+import {
+  NotificationMobileHeader,
+  // NotificationPopupCard,
+} from '@/widgets/notification';
+import { UserGreetingHeader } from '@/widgets/user';
+
+import { useMyInfoSuspenseQuery } from '@/entities/auth';
+
+import { QuickMenu } from '@/shared/ui';
+
+export function HomePageContent() {
+  const { data: myInfo } = useMyInfoSuspenseQuery();
+  const isAlumni = myInfo.academicStatus === 'GRADUATED';
+
+  return (
+    <VStack className="tablet:gap-8 max-w-desktop tablet:px-8 tablet:pt-12 desktop:gap-6 mx-auto w-full gap-2 px-4 pb-[2.125rem]">
+      <div className="tablet:hidden sticky top-0 z-10">
+        <NotificationMobileHeader />
+      </div>
+
+      <div className="tablet:block hidden">
+        <Suspense fallback={<Skeleton width={400} height={52} />}>
+          <UserGreetingHeader />
+        </Suspense>
+      </div>
+
+      <VStack className="desktop:gap-6 gap-4">
+        {isAlumni && (
+          <div className="desktop:block hidden">
+            <CeremonyRegisterBanner />
+          </div>
+        )}
+
+        <div className="desktop:grid-cols-2 desktop:gap-x-6 desktop:gap-y-8 grid w-full grid-cols-1 gap-4">
+          {!isAlumni && <QuickMenu />}
+
+          {!isAlumni && (
+            <div className="desktop:block hidden">
+              <CeremonyRegisterBanner />
+            </div>
+          )}
+
+          <CalendarEventListPreview />
+
+          <div className="desktop:hidden">
+            <CeremonyRegisterBanner />
+          </div>
+          <CeremonyListPreview />
+        </div>
+      </VStack>
+    </VStack>
+  );
+}

--- a/apps/web/src/widgets/home/ui/home-page-content/index.ts
+++ b/apps/web/src/widgets/home/ui/home-page-content/index.ts
@@ -1,0 +1,1 @@
+export { HomePageContent } from './HomePageContent';

--- a/apps/web/src/widgets/navigation-layout/model/navItems.tsx
+++ b/apps/web/src/widgets/navigation-layout/model/navItems.tsx
@@ -1,13 +1,4 @@
-import {
-  Bell,
-  Board,
-  Book,
-  Contacts,
-  Home,
-  Pen,
-  Question,
-  Setting,
-} from '@causw/cds';
+import { Bell, Board, Book, Contacts, Home, Pen, Setting } from '@causw/cds';
 
 import { type BottomNavItem, type SidebarItem } from './types';
 
@@ -40,12 +31,12 @@ export const SIDEBAR_MAIN_ITEMS: SidebarItem[] = [
 ];
 
 export const SIDEBAR_BOTTOM_ITEMS: SidebarItem[] = [
-  {
-    key: 'info',
-    label: '크자회 소개',
-    icon: <Question size={18} />,
-    href: '/info',
-  },
+  // {
+  //   key: 'info',
+  //   label: '크자회 소개',
+  //   icon: <Question size={18} />,
+  //   href: '/info',
+  // },
   {
     key: 'notifications',
     label: '알림',


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #179 


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 백엔드 인증 DTO 변경에 맞춰 refreshToken을 응답 기반으로 저장/갱신하도록 인증 흐름을 수정했습니다.


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- 로그인, 회원가입, 소셜 로그인, 추가 정보 입력 응답에서 내려오는 `refreshToken`을 클라이언트 저장소에 저장하도록 수정했습니다.
- 데스크톱 소셜 로그인 콜백에서 query params로 전달되는 `refreshToken`을 받아 토큰 재발급 후 저장하도록 변경했습니다.
- 토큰 재발급 요청 시 `Refresh-Authorization` 헤더에 현재 refreshToken을 명시적으로 담아 보내도록 수정했습니다.
- proxy에서 accessToken 만료 임박 여부를 JWT exp 기준으로 확인하고, 필요한 경우 요청 전에 토큰을 갱신하도록 추가했습니다.
- SSR 과정에서 발생하는 토큰 갱신은 수행하지 않는 방향으로 수정.
- 로그아웃 API에 `Refresh-Authorization` 헤더를 추가하고, 로그아웃 후 auth route에서 query cache를 정리하도록 변경했습니다.
- Next 정적 리소스가 proxy 인증 로직에 걸리지 않도록 matcher를 추가했습니다.
- 홈 페이지에서 유저 역할에 맞게 페이지 구성 변경 api 연동


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- proxy에서 토큰 만료 임박 시 refresh하는 로직이 의도한 라우트에서만 동작하는지 확인해주세요.
- 미들웨어에서의 토큰 갱신 이후 `auth_refreshed` 플래그를 통한 클라이언트 동기화 흐름을 확인해주세요.


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.

- `pnpm -C apps/web exec tsc -p tsconfig.json --noEmit` 통과


## 📎 Additional Notes
- 백엔드 인증 API 변경에 따라 refreshToken을 쿠키가 아닌 응답/body 기반으로 처리하는 방향으로 맞췄습니다.
