### PR TITLE
[FEAT/#174] 게시글 작성/수정 API 연동 수정

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -4,6 +4,16 @@ import { withSentryConfig } from '@causw/logger/config';
 
 const nextConfig: NextConfig = {
   transpilePackages: ['@causw/logger'],
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'caucse-s3-bucket.s3.ap-northeast-2.amazonaws.com',
+        port: '',
+        pathname: '/**',
+      },
+    ],
+  },
 };
 
 export default withSentryConfig<NextConfig>(nextConfig, 'causw');

--- a/apps/web/src/app/_mock/handlers.ts
+++ b/apps/web/src/app/_mock/handlers.ts
@@ -2,11 +2,9 @@
 import { authHandler } from '@/features/auth/mock';
 
 import { alumniContactsHandler } from '@/entities/alumni-contacts';
-import { boardsHandler } from '@/entities/feed';
 import { notificationHandler } from '@/entities/notification';
 
 export const handlers = [
-  ...boardsHandler,
   ...notificationHandler,
   ...authHandler,
   ...alumniContactsHandler,

--- a/apps/web/src/entities/comment/model/types/index.ts
+++ b/apps/web/src/entities/comment/model/types/index.ts
@@ -1,4 +1,4 @@
-import { type PaginationDto } from '@/shared/types';
+import { type ProfileImageValue, type PaginationDto } from '@/shared/types';
 
 export interface BaseComment {
   id: string;
@@ -10,7 +10,7 @@ export interface BaseComment {
   writerNickname: string;
   displayWriterNickname: string;
   writerAdmissionYear: number;
-  writerProfileImage: string;
+  writerProfileImage: ProfileImageValue;
   updatable: boolean;
   deletable: boolean;
   isBlocked: boolean;

--- a/apps/web/src/entities/comment/ui/CommentCard.tsx
+++ b/apps/web/src/entities/comment/ui/CommentCard.tsx
@@ -2,11 +2,13 @@ import { type ReactNode } from 'react';
 
 import { Avatar, Heart, HStack, VStack, Text } from '@causw/cds';
 
+import { getProfileImageUrl } from '@/shared/lib';
+import { type ProfileImageValue } from '@/shared/types';
 import { IconCountButton } from '@/shared/ui';
 
 interface CommentCardProps {
   author: string;
-  profileImage: string;
+  profileImage: ProfileImageValue;
   content: string;
   time: string;
   isDeleted?: boolean;
@@ -35,12 +37,20 @@ export const CommentCard = ({
 }: CommentCardProps) => {
   const isInactive = isDeleted || isBlocked;
 
+  const profileImageUrl = profileImage
+    ? getProfileImageUrl({
+        profileImageType: profileImage.profileImageType,
+        profileImageUrl: profileImage.profileImageUrl,
+        width: 36,
+      })
+    : '';
+
   return (
     <article className={`bg-white px-5 py-3 ${isReply && 'pl-12'}`}>
       <HStack align={isInactive ? 'center' : 'start'} className="gap-3">
         <Avatar
           size={36}
-          src={profileImage}
+          src={profileImageUrl}
           className="my-1 shrink-0"
           isRestricted={isBlocked}
         />

--- a/apps/web/src/entities/post/model/form/schema.ts
+++ b/apps/web/src/entities/post/model/form/schema.ts
@@ -41,6 +41,10 @@ export const postCreateSchema = z
   });
 
 export type PostCreateFormValues = z.infer<typeof postCreateSchema>;
+export type PostUpdateFormValues = PostCreateFormValues & {
+  existingImages?: string[];
+  newImageFiles?: File[];
+};
 
 export const usePostCreateForm = (
   defaultValues?: Partial<PostCreateFormValues>,

--- a/apps/web/src/entities/post/model/types/detail.ts
+++ b/apps/web/src/entities/post/model/types/detail.ts
@@ -1,10 +1,12 @@
+import { type ProfileImageValue } from '@/shared/types';
+
 /* 게시글 단일 조회 */
 export interface GetPostResponseDto {
   id: string;
   content: string;
   isDeleted: boolean;
   displayWriterNickname: string;
-  writerProfileImage: string;
+  writerProfileImage: ProfileImageValue;
   fileUrlList: string[];
   numComment: number;
   numLike: number;

--- a/apps/web/src/entities/post/model/types/update.ts
+++ b/apps/web/src/entities/post/model/types/update.ts
@@ -1,6 +1,17 @@
+export type PostImageType = 'existing' | 'new';
+
+export interface PostImageMeta {
+  order: number;
+  type: PostImageType;
+  url?: string;
+  fileIndex?: number;
+  isRepresentative: boolean;
+}
+
 export interface PostUpdateRequestDto {
   content: string;
   isAnonymous: boolean;
+  images: PostImageMeta[];
 }
 
 export interface PostUpdateResponseDto {

--- a/apps/web/src/entities/post/model/types/write.ts
+++ b/apps/web/src/entities/post/model/types/write.ts
@@ -1,5 +1,5 @@
 /* 게시글 작성 */
-export interface PostImage {
+export interface PostMetaImage {
   order: number;
   fileIndex: number;
   isRepresentative: boolean;
@@ -9,7 +9,7 @@ export interface PostCreateRequestDto {
   content: string;
   boardId: string;
   isAnonymous: boolean;
-  iamges: PostImage[];
+  images: PostMetaImage[];
 }
 
 export interface PostCreateResponseDto {

--- a/apps/web/src/entities/post/model/types/write.ts
+++ b/apps/web/src/entities/post/model/types/write.ts
@@ -1,8 +1,15 @@
 /* 게시글 작성 */
+export interface PostImage {
+  order: number;
+  fileIndex: number;
+  isRepresentative: boolean;
+}
+
 export interface PostCreateRequestDto {
   content: string;
   boardId: string;
   isAnonymous: boolean;
+  iamges: PostImage[];
 }
 
 export interface PostCreateResponseDto {

--- a/apps/web/src/features/post/api/post/index.ts
+++ b/apps/web/src/features/post/api/post/index.ts
@@ -7,21 +7,21 @@ import { API } from '@/shared/api';
 
 /* 게시글 작성 */
 export const createPost = (
-  postCreateRequest: PostCreateRequestDto,
-  attachImageList?: File[],
+  request: PostCreateRequestDto,
+  imageFiles?: File[],
 ) => {
   const formData = new FormData();
 
   formData.append(
-    'postCreateRequest',
-    new Blob([JSON.stringify(postCreateRequest)], {
+    'request',
+    new Blob([JSON.stringify(request)], {
       type: 'application/json',
     }),
   );
 
-  if (attachImageList && attachImageList.length > 0) {
-    attachImageList.forEach((file) => {
-      formData.append('attachImageList', file);
+  if (imageFiles && imageFiles.length > 0) {
+    imageFiles.forEach((file) => {
+      formData.append('images', file);
     });
   }
 

--- a/apps/web/src/features/post/api/put/index.ts
+++ b/apps/web/src/features/post/api/put/index.ts
@@ -8,21 +8,21 @@ import { API } from '@/shared/api';
 /* 게시글 수정 */
 export const updatePost = (
   postId: string,
-  postUpdateRequest: PostUpdateRequestDto,
-  attachImageList?: File[],
+  request: PostUpdateRequestDto,
+  imageFiles?: File[],
 ) => {
   const formData = new FormData();
 
   formData.append(
-    'postUpdateRequest',
-    new Blob([JSON.stringify(postUpdateRequest)], {
+    'request',
+    new Blob([JSON.stringify(request)], {
       type: 'application/json',
     }),
   );
 
-  if (attachImageList && attachImageList.length > 0) {
-    attachImageList.forEach((file) => {
-      formData.append('attachImageList', file);
+  if (imageFiles && imageFiles.length > 0) {
+    imageFiles.forEach((file) => {
+      formData.append('images', file);
     });
   }
 

--- a/apps/web/src/features/post/lib/mappers.ts
+++ b/apps/web/src/features/post/lib/mappers.ts
@@ -1,20 +1,24 @@
 import type {
   PostCreateFormValues,
   PostCreateRequestDto,
+  PostImageMeta,
   PostMetaImage,
+  PostUpdateFormValues,
   PostUpdateRequestDto,
 } from '@/entities/post';
 
-const mapFilesToPostMetaImages = (files: File[]): PostMetaImage[] =>
-  files.map((_, index) => ({
+const mapFilesToPostMetaImages = (files?: File[]): PostMetaImage[] => {
+  if (!files || !Array.isArray(files)) {
+    return [];
+  }
+
+  return files.map((_, index) => ({
     order: index,
     fileIndex: index,
     isRepresentative: index === 0,
   }));
+};
 
-/**
- * 게시글 작성 Form 데이터를 서버 요청 DTO 형태로 변환
- */
 export const mapPostCreateFormToDto = (
   data: PostCreateFormValues,
 ): PostCreateRequestDto => {
@@ -26,14 +30,30 @@ export const mapPostCreateFormToDto = (
   };
 };
 
-/**
- * 게시글 수정 Form 데이터를 서버 요청 DTO 형태로 변환
- */
 export const mapPostUpdateFormToDto = (
-  data: PostCreateFormValues,
+  data: PostUpdateFormValues,
 ): PostUpdateRequestDto => {
+  const existingImages: PostImageMeta[] = (data.existingImages ?? []).map(
+    (url, index) => ({
+      type: 'existing' as const,
+      order: index,
+      isRepresentative: index === 0,
+      url,
+    }),
+  );
+
+  const newImages: PostImageMeta[] = (data.newImageFiles ?? []).map(
+    (_, index) => ({
+      type: 'new' as const,
+      order: (data.existingImages?.length ?? 0) + index,
+      isRepresentative: (data.existingImages?.length ?? 0) === 0 && index === 0,
+      fileIndex: index,
+    }),
+  );
+
   return {
     content: data.content,
     isAnonymous: data.isAnonymous,
+    images: [...existingImages, ...newImages],
   };
 };

--- a/apps/web/src/features/post/lib/mappers.ts
+++ b/apps/web/src/features/post/lib/mappers.ts
@@ -1,8 +1,16 @@
-import {
-  type PostCreateFormValues,
-  type PostCreateRequestDto,
-  type PostUpdateRequestDto,
+import type {
+  PostCreateFormValues,
+  PostCreateRequestDto,
+  PostMetaImage,
+  PostUpdateRequestDto,
 } from '@/entities/post';
+
+const mapFilesToPostMetaImages = (files: File[]): PostMetaImage[] =>
+  files.map((_, index) => ({
+    order: index,
+    fileIndex: index,
+    isRepresentative: index === 0,
+  }));
 
 /**
  * 게시글 작성 Form 데이터를 서버 요청 DTO 형태로 변환
@@ -14,6 +22,7 @@ export const mapPostCreateFormToDto = (
     content: data.content,
     boardId: data.boardId,
     isAnonymous: data.isAnonymous,
+    images: mapFilesToPostMetaImages(data.images),
   };
 };
 

--- a/apps/web/src/features/post/model/mutations/useCreatePostMutation.ts
+++ b/apps/web/src/features/post/model/mutations/useCreatePostMutation.ts
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import {
   type PostCreateRequestDto,
@@ -14,28 +14,27 @@ import { toast } from '@/shared/model';
 import { createPost } from '../../api';
 
 interface CreatePostParams {
-  postCreateRequest: PostCreateRequestDto;
-  attachImageList: File[];
+  request: PostCreateRequestDto;
+  images: File[];
 }
 
 export const useCreatePostMutation = () => {
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   return useMutation<PostCreateResponseDto, Error, CreatePostParams>({
-    mutationFn: ({ postCreateRequest, attachImageList }) =>
-      createPost(postCreateRequest, attachImageList),
+    mutationFn: ({ request, images }) => createPost(request, images),
 
-    onSuccess: () => {
+    onSuccess: (data) => {
       toast.success('게시글이 작성되었어요.');
 
-      // TODO: 작성 후 게시글 목록 invalidateQueries 필요
-      // queryClient.invalidateQueries({
-      //   queryKey: ['feed'],
-      // });
+      queryClient.invalidateQueries({
+        queryKey: ['feed'],
+      });
 
       router.back();
       setTimeout(() => {
-        router.replace('/feed');
+        router.push(`/feed/${data.id}`);
       }, 0);
     },
 

--- a/apps/web/src/features/post/model/mutations/useUpdatePostMutation.ts
+++ b/apps/web/src/features/post/model/mutations/useUpdatePostMutation.ts
@@ -12,8 +12,8 @@ import { updatePost } from '../../api';
 
 interface UpdatePostParams {
   postId: string;
-  postUpdateRequest: PostUpdateRequestDto;
-  attachImageList?: File[];
+  request: PostUpdateRequestDto;
+  images?: File[];
 }
 
 export const useUpdatePostMutation = () => {
@@ -21,12 +21,8 @@ export const useUpdatePostMutation = () => {
   const router = useRouter();
 
   return useMutation({
-    mutationFn: ({
-      postId,
-      postUpdateRequest,
-      attachImageList,
-    }: UpdatePostParams) =>
-      updatePost(postId, postUpdateRequest, attachImageList),
+    mutationFn: ({ postId, request, images }: UpdatePostParams) =>
+      updatePost(postId, request, images),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: postKeys.all });
       router.back();

--- a/apps/web/src/features/post/ui/PostEditForm.tsx
+++ b/apps/web/src/features/post/ui/PostEditForm.tsx
@@ -20,9 +20,10 @@ export const PostEditForm = ({ postId, onClose }: PostEditFormProps) => {
         content: post.content,
         boardId: post.boardId,
         isAnonymous: post.isAnonymous,
-        images: [],
+        images: (post.fileUrlList || []) as unknown as File[],
         vote: null,
       }}
+      initialImages={post.fileUrlList}
     />
   );
 };

--- a/apps/web/src/features/post/ui/PostHeader.tsx
+++ b/apps/web/src/features/post/ui/PostHeader.tsx
@@ -1,6 +1,7 @@
 import { Avatar, Flex, HStack, OfficialColored, Text } from '@causw/cds';
 
-import { formatRelativeTime } from '@/shared/lib';
+import { formatRelativeTime, getProfileImageUrl } from '@/shared/lib';
+import { type ProfileImageValue } from '@/shared/types';
 
 import { type PostAction } from '../config';
 
@@ -9,7 +10,7 @@ import { PostActionMenu } from './PostActionMenu';
 interface PostHeaderProps {
   authorName: string;
   createdAt: string;
-  avatarUrl?: string;
+  profileImage?: ProfileImageValue;
   isOfficial?: boolean;
   isMine: boolean;
   onAction: (action: PostAction) => void;
@@ -24,15 +25,23 @@ interface PostHeaderProps {
 export const PostHeader = ({
   authorName,
   createdAt,
-  avatarUrl,
+  profileImage,
   isOfficial = false,
   isMine,
   onAction,
 }: PostHeaderProps) => {
+  const profileImageUrl = profileImage
+    ? getProfileImageUrl({
+        profileImageType: profileImage.profileImageType,
+        profileImageUrl: profileImage.profileImageUrl,
+        width: 40,
+      })
+    : '';
+
   return (
     <Flex as="header" gap="none" align="center">
       <HStack gap="sm" align="center" className="flex-1 gap-2.5">
-        <Avatar size={40} src={avatarUrl} className="shrink-0" />
+        <Avatar size={40} src={profileImageUrl} className="shrink-0" />
 
         <HStack gap="sm" align="center">
           <HStack gap="xs" align="center">

--- a/apps/web/src/features/post/ui/PostWriteForm.tsx
+++ b/apps/web/src/features/post/ui/PostWriteForm.tsx
@@ -7,7 +7,11 @@ import { FormProvider } from 'react-hook-form';
 import { Box, Dialog, VStack } from '@causw/cds';
 
 import { type Board, useGetAvailableBoards } from '@/entities/feed';
-import { type PostCreateFormValues, usePostCreateForm } from '@/entities/post';
+import {
+  type PostCreateFormValues,
+  type PostUpdateFormValues,
+  usePostCreateForm,
+} from '@/entities/post';
 
 import { ImageUploadField, type ImageUploadFieldRef } from '@/shared/ui';
 
@@ -24,12 +28,14 @@ interface PostWriteFormProps {
   onClose: (isDirty: boolean) => void;
   postId?: string;
   initialData?: Partial<PostCreateFormValues>;
+  initialImages?: string[];
 }
 
 export const PostWriteForm = ({
   onClose,
   postId,
   initialData,
+  initialImages = [],
 }: PostWriteFormProps) => {
   const isEdit = !!postId;
   const { data: boardData } = useGetAvailableBoards();
@@ -58,19 +64,39 @@ export const PostWriteForm = ({
 
   const onSubmit = async (data: PostCreateFormValues) => {
     if (isEdit) {
-      const updateDto = mapPostUpdateFormToDto(data);
+      const imageData = data.images as {
+        existingImages?: string[];
+        newImageFiles?: File[];
+      };
+
+      const existingImages = imageData?.existingImages ?? [];
+      const newImageFiles = imageData?.newImageFiles ?? [];
+
+      const updateData: PostUpdateFormValues = {
+        ...data,
+        existingImages,
+        newImageFiles,
+      };
+
+      const updateDto = mapPostUpdateFormToDto(updateData);
 
       updatePost({
         postId,
-        postUpdateRequest: updateDto,
-        attachImageList: data.images,
+        request: updateDto,
+        images: newImageFiles,
       });
     } else {
+      const imageData = data.images as {
+        existingImages?: string[];
+        newImageFiles?: File[];
+      };
+      const newImageFiles = imageData?.newImageFiles ?? [];
+
       const createDto = mapPostCreateFormToDto(data);
 
       createPost({
-        postCreateRequest: createDto,
-        attachImageList: data.images,
+        request: createDto,
+        images: newImageFiles,
       });
     }
   };
@@ -121,6 +147,7 @@ export const PostWriteForm = ({
             name="images"
             setValue={setValue}
             showMainBadge
+            initialImages={initialImages}
           />
         </Box>
 

--- a/apps/web/src/shared/types/image/image.ts
+++ b/apps/web/src/shared/types/image/image.ts
@@ -29,4 +29,5 @@ export interface ImageUploadFieldProps<T extends FieldValues> {
   resetTrigger?: boolean;
   showMainBadge?: boolean;
   children?: React.ReactNode;
+  initialImages?: string[];
 }

--- a/apps/web/src/shared/types/profile-image/index.ts
+++ b/apps/web/src/shared/types/profile-image/index.ts
@@ -3,5 +3,6 @@ export type {
   ChangeMyProfileImageRequest,
   DefaultProfileImageType,
   ProfileImageEditValue,
+  ProfileImageValue,
   UserProfileImageType,
 } from './profileImage';

--- a/apps/web/src/shared/types/profile-image/profileImage.ts
+++ b/apps/web/src/shared/types/profile-image/profileImage.ts
@@ -32,3 +32,8 @@ export interface ProfileImageEditValue {
   profileImageUrl?: string | null;
   customImageFile?: File | null;
 }
+
+export interface ProfileImageValue {
+  profileImageType: UserProfileImageType;
+  profileImageUrl?: string | null;
+}

--- a/apps/web/src/shared/ui/image/ImageUploadField.tsx
+++ b/apps/web/src/shared/ui/image/ImageUploadField.tsx
@@ -22,10 +22,13 @@ const ImageUploadFieldInner = <T extends FieldValues>(
     maxFiles = IMAGE_UPLOAD_RULES.MAX_FILE_COUNT,
     resetTrigger,
     showMainBadge = false,
+    initialImages = [],
   }: Omit<ImageUploadFieldProps<T>, 'label' | 'errorMessage' | 'children'>,
   ref: React.ForwardedRef<ImageUploadFieldRef>,
 ) => {
-  const [previews, setPreviews] = React.useState<string[]>([]);
+  const [previews, setPreviews] = React.useState<string[]>(initialImages);
+  const [existingImages, setExistingImages] =
+    React.useState<string[]>(initialImages);
   const [files, setFiles] = React.useState<File[]>([]);
   const inputRef = React.useRef<HTMLInputElement>(null);
   const previewsRef = React.useRef<string[]>([]);
@@ -49,21 +52,31 @@ const ImageUploadFieldInner = <T extends FieldValues>(
 
   // resetTrigger 변경 시 초기화
   React.useEffect(() => {
-    previews.forEach((url) => URL.revokeObjectURL(url));
-    setPreviews([]);
-    setFiles([]);
-    setValue(name, [] as Parameters<typeof setValue>[1]);
+    if (resetTrigger !== undefined) {
+      previews.forEach((url) => URL.revokeObjectURL(url));
+      setPreviews(initialImages);
+      setExistingImages(initialImages);
+      setFiles([]);
+      setValue(name, [] as Parameters<typeof setValue>[1]);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resetTrigger]);
 
   // files 변경 시 form에 반영
   React.useEffect(() => {
-    setValue(name, files as Parameters<typeof setValue>[1], {
-      shouldValidate: files.length > 0, // 초기 렌더링 시에는 검증 생략
-      shouldDirty: true,
-      shouldTouch: true,
-    });
-  }, [files, name, setValue]);
+    setValue(
+      name,
+      {
+        existingImages,
+        newImageFiles: files,
+      } as Parameters<typeof setValue>[1],
+      {
+        shouldValidate: files.length > 0,
+        shouldDirty: true,
+        shouldTouch: true,
+      },
+    );
+  }, [files, existingImages, name, setValue]);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFiles = Array.from(e.target.files || []);
@@ -93,13 +106,30 @@ const ImageUploadFieldInner = <T extends FieldValues>(
     }
   };
 
-  const handleRemove = (index: number) => {
-    URL.revokeObjectURL(previews[index]);
-    setPreviews((prev) => prev.filter((_, i) => i !== index));
-    setFiles((prev) => prev.filter((_, i) => i !== index));
+  const handleRemoveExisting = (index: number) => {
+    setExistingImages((prev) => prev.filter((_, i) => i !== index));
+    setPreviews((prev) => {
+      const newPreviews = prev.filter((_, i) => {
+        const existingCount = existingImages.length;
+        return i >= existingCount || prev[i] !== existingImages[index];
+      });
+      return newPreviews.filter(
+        (url) => !existingImages.includes(url) || url !== existingImages[index],
+      );
+    });
   };
 
-  if (previews.length === 0) {
+  const handleRemoveNew = (index: number) => {
+    const newImageStartIndex = existingImages.length;
+    const newImageIndex = index - newImageStartIndex;
+    if (newImageIndex >= 0) {
+      URL.revokeObjectURL(previews[index]);
+      setFiles((prev) => prev.filter((_, i) => i !== newImageIndex));
+      setPreviews((prev) => prev.filter((_, i) => i !== index));
+    }
+  };
+
+  if (previews.length === 0 && existingImages.length === 0) {
     return (
       <input
         ref={inputRef}
@@ -123,15 +153,15 @@ const ImageUploadFieldInner = <T extends FieldValues>(
         className="hidden"
       />
 
-      <div className="flex h-[6.25rem] gap-[0.5rem] overflow-x-auto">
-        {previews.map((preview, index) => (
+      <div className="flex h-25 gap-2 overflow-x-auto">
+        {existingImages.map((url, index) => (
           <div
-            key={preview}
-            className="relative h-[6.25rem] w-[6.25rem] flex-shrink-0 overflow-hidden rounded-lg bg-gray-200"
+            key={`existing-${url}-${index}`}
+            className="relative h-25 w-25 shrink-0 overflow-hidden rounded-lg bg-gray-200"
           >
             <Image
-              src={preview}
-              alt={`업로드 이미지 ${index + 1}`}
+              src={url}
+              alt={`기존 이미지 ${index + 1}`}
               fill
               className="object-cover"
             />
@@ -139,8 +169,8 @@ const ImageUploadFieldInner = <T extends FieldValues>(
             {/* 삭제 버튼 */}
             <button
               type="button"
-              onClick={() => handleRemove(index)}
-              className="absolute top-[0.375rem] right-[0.375rem] flex h-5 w-5 items-center justify-center"
+              onClick={() => handleRemoveExisting(index)}
+              className="absolute top-1.5 right-1.5 flex h-5 w-5 items-center justify-center"
               aria-label="이미지 삭제"
             >
               <CloseFilled size={18} color="gray-600" />
@@ -148,7 +178,7 @@ const ImageUploadFieldInner = <T extends FieldValues>(
 
             {/* 대표 사진 배지 */}
             {showMainBadge && index === 0 && (
-              <div className="absolute right-0 bottom-0 left-0 flex h-[1.75rem] items-center justify-center bg-gray-600">
+              <div className="absolute right-0 bottom-0 left-0 flex h-7 items-center justify-center bg-gray-600">
                 <span className="text-[0.875rem] leading-[160%] font-semibold tracking-[-0.02em] text-gray-50">
                   대표 사진
                 </span>
@@ -156,6 +186,41 @@ const ImageUploadFieldInner = <T extends FieldValues>(
             )}
           </div>
         ))}
+        {files.map((_, index) => {
+          const previewIndex = existingImages.length + index;
+          return (
+            <div
+              key={`new-${previewIndex}`}
+              className="relative h-25 w-25 shrink-0 overflow-hidden rounded-lg bg-gray-200"
+            >
+              <Image
+                src={previews[previewIndex]}
+                alt={`새 이미지 ${index + 1}`}
+                fill
+                className="object-cover"
+              />
+
+              {/* 삭제 버튼 */}
+              <button
+                type="button"
+                onClick={() => handleRemoveNew(index)}
+                className="absolute top-1.5 right-1.5 flex h-5 w-5 items-center justify-center"
+                aria-label="이미지 삭제"
+              >
+                <CloseFilled size={18} color="gray-600" />
+              </button>
+
+              {/* 대표 사진 배지 */}
+              {showMainBadge && previewIndex === 0 && (
+                <div className="absolute right-0 bottom-0 left-0 flex h-7 items-center justify-center bg-gray-600">
+                  <span className="text-[0.875rem] leading-[160%] font-semibold tracking-[-0.02em] text-gray-50">
+                    대표 사진
+                  </span>
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
     </>
   );

--- a/apps/web/src/widgets/post/ui/PostContent.tsx
+++ b/apps/web/src/widgets/post/ui/PostContent.tsx
@@ -46,7 +46,7 @@ export const PostContent = ({ post }: PostContentProps) => {
         <PostHeader
           authorName={post.displayWriterNickname}
           createdAt={post.createdAt}
-          avatarUrl={post.writerProfileImage}
+          profileImage={post.writerProfileImage}
           // TODO: 작성자 이름 오른쪽 체크 표시 여부 필요
           // isOfficial={}
           isMine={post.isOwner}


### PR DESCRIPTION
# 🚀 Pull Request

## Issue

- Closes #174 

## ✨ Summary

게시글 작성/수정 시 이미지 처리 구조를 개선하고, 
API 스펙 변경에 맞게 요청 형태를 수정했습니다.

## 📚 Details of Changes

- [x] 게시글 작성(생성) 및 수정 formData 필드명 수정
- postCreateRequest / postUpdateRequest → `request`
- attachImageList → `images`
- [x] 게시글 수정 dto 매핑 로직 변경
- 기존 이미지 / 신규 이미지 구분하도록
- [x] 이미지 데이터 구조 개선
- `ImageUploadField` 컴포넌트
- 게시글 수정 시에도 컴포넌트를 사용할 수 있도록 하기 위함
- 기존 File[] 단일 구조에서 → 기존 이미지와 신규 이미지를 분리하여 관리하도록 변경
- [x] 게시글 및 댓글 프로필 이미지 `getProfileImageUrl` 유틸로 가져와서 사용하도록 수정

## 🎯 Key points to review

- 


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

<img width="1504" height="984" alt="image" src="https://github.com/user-attachments/assets/111c3300-cc67-4ed9-9b6b-80633e39d096" />

## 📎 Additional Notes
-
