### PR TITLE
[FIX/#201] 동문수첩 수정 페이지 오류 수정

### DIFF
--- a/apps/web/src/entities/alumni-contacts/model/form/schema.ts
+++ b/apps/web/src/entities/alumni-contacts/model/form/schema.ts
@@ -27,7 +27,7 @@ export const alumniContactsEditSchema = z.object({
     .string()
     .min(0)
     .max(ALUMNI_CONTACTS_EDIT_FORM_MAX_LENGTH.DESCRIPTION)
-    .optional(),
+    .nullable(),
   isPhoneNumberVisible: z.boolean(),
   socialLinks: z
     .array(z.string())

--- a/apps/web/src/entities/alumni-contacts/model/form/schema.ts
+++ b/apps/web/src/entities/alumni-contacts/model/form/schema.ts
@@ -26,7 +26,8 @@ export const alumniContactsEditSchema = z.object({
   description: z
     .string()
     .min(0)
-    .max(ALUMNI_CONTACTS_EDIT_FORM_MAX_LENGTH.DESCRIPTION),
+    .max(ALUMNI_CONTACTS_EDIT_FORM_MAX_LENGTH.DESCRIPTION)
+    .optional(),
   isPhoneNumberVisible: z.boolean(),
   socialLinks: z
     .array(z.string())

--- a/apps/web/src/entities/alumni-contacts/model/types/alumniContactsDetail.ts
+++ b/apps/web/src/entities/alumni-contacts/model/types/alumniContactsDetail.ts
@@ -29,7 +29,7 @@ export interface AlumniContactsDetail {
   name: string;
   admissionYear: string;
   academicStatus: string;
-  description: string;
+  description?: string;
   phoneNumber: string;
   isPhoneNumberVisible: boolean;
   email: string;

--- a/apps/web/src/entities/alumni-contacts/model/types/alumniContactsDetail.ts
+++ b/apps/web/src/entities/alumni-contacts/model/types/alumniContactsDetail.ts
@@ -29,7 +29,7 @@ export interface AlumniContactsDetail {
   name: string;
   admissionYear: string;
   academicStatus: string;
-  description?: string;
+  description: string | null;
   phoneNumber: string;
   isPhoneNumberVisible: boolean;
   email: string;

--- a/apps/web/src/features/alumni-contacts/model/hooks/useAlumniContactsDescriptionTextArea.ts
+++ b/apps/web/src/features/alumni-contacts/model/hooks/useAlumniContactsDescriptionTextArea.ts
@@ -24,7 +24,7 @@ export const useAlumniContactsDescriptionTextArea = () => {
     const textarea = textareaRef.current;
     if (!textarea) return;
 
-    if (field.value.length === 0) {
+    if (!field.value || field.value.length === 0) {
       textarea.style.height = '24px';
       return;
     }

--- a/apps/web/src/features/alumni-contacts/ui/alumni-contacts-description-text-area/AlumniContactsDescriptionTextArea.tsx
+++ b/apps/web/src/features/alumni-contacts/ui/alumni-contacts-description-text-area/AlumniContactsDescriptionTextArea.tsx
@@ -16,7 +16,7 @@ export const AlumniContactsDescriptionTextArea = () => {
         resize={false}
         maxLength={ALUMNI_CONTACTS_EDIT_FORM_MAX_LENGTH.DESCRIPTION}
         className="min-h-0 grow text-white caret-white"
-        value={field.value}
+        value={field.value ?? ''}
         onChange={handleTextAreaChange}
         onBlur={field.onBlur}
         ref={textareaRef}


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #201


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 동문수첩 수정 페이지에서 description이 null일 때 발생하던 런타임 에러를 수정했습니다.


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- 동문수첩 상세 응답의 description 타입을 nullable하게 수정했습니다.
- 동문수첩 수정 폼 schema에서 description의 null 값을 허용하도록 수정했습니다.
- description textarea에서 null 값이 들어와도 빈 문자열로 렌더링되도록 방어 로직을 추가했습니다.
- textarea 높이 계산 시 description 값이 비어 있거나 null인 경우를 처리하도록 수정했습니다.


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- 신규 생성된 동문수첩의 description이 null로 내려올 때 수정 페이지가 정상 렌더링되는지 확인해주세요.
- description이 null인 상태에서 수정 저장 시 폼 검증 및 요청 데이터 흐름이 의도대로 동작하는지 확인해주세요.


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.

- `pnpm --filter @causw/web build` 완료
- `pnpm --filter @causw/web lint` 완료 (기존 warning 6건 확인)


## 📎 Additional Notes
- Storybook 검증은 별도로 수행하지 않았습니다.
