### PR TITLE
[FIX] 카카오, 구글 client id에 환경별 분기 추가 & 구글 클라우드 콘솔 및 카카오 개발자 콘솔에서도 서명키값에 맞춰서 분기

### DIFF
--- a/apps/web/android/app/build.gradle
+++ b/apps/web/android/app/build.gradle
@@ -30,10 +30,16 @@ if (localPropertiesFile.exists()) {
         localProperties.load(reader)
     }
 }
-    def googleWebClientId = localProperties.getProperty(
-        'googleWebClientId',
-        '1086770319771-hp040om1msg7r4o25u895b1pos47jkjt.apps.googleusercontent.com'
-    )
+    def googleWebClientId = localProperties.getProperty('googleWebClientId')
+    def googleAndroidClientIdDebug = localProperties.getProperty('googleAndroidClientIdDebug')
+    def googleAndroidClientIdDevRelease = localProperties.getProperty('googleAndroidClientIdDevRelease')
+    def googleAndroidClientIdProdRelease = localProperties.getProperty('googleAndroidClientIdProdRelease')
+    def kakaoNativeAppKeyDebug = localProperties.getProperty('kakaoNativeAppKeyDebug')
+    def kakaoNativeAppKeyDevRelease = localProperties.getProperty('kakaoNativeAppKeyDevRelease')
+    def kakaoNativeAppKeyProdRelease = localProperties.getProperty('kakaoNativeAppKeyProdRelease')
+    def kakaoSchemeDebug = localProperties.getProperty('kakaoSchemeDebug')
+    def kakaoSchemeDevRelease = localProperties.getProperty('kakaoSchemeDevRelease')
+    def kakaoSchemeProdRelease = localProperties.getProperty('kakaoSchemeProdRelease')
     signingConfigs {
         release {
             storeFile file(localProperties.getProperty('storeFile'))
@@ -51,11 +57,12 @@ if (localPropertiesFile.exists()) {
 
             resValue "string", "package_name", "kr.co.causwv2.twa.dev"
             resValue "string", "custom_url_scheme", "kr.co.causwv2.twa.dev"
-            resValue "string", "kakao_native_app_key", "0d6f887e12de1e823fc6d021e90da922"
+            resValue "string", "kakao_native_app_key", kakaoNativeAppKeyDevRelease
+            resValue "string", "google_android_client_id", googleAndroidClientIdDevRelease
             resValue "string", "google_web_client_id", googleWebClientId
             manifestPlaceholders = [
                 appLabel: "DEV-크자회",
-                kakaoScheme: "kakao0d6f887e12de1e823fc6d021e90da922"
+                kakaoScheme: kakaoSchemeDevRelease
             ]
 
             versionCode 20
@@ -64,11 +71,12 @@ if (localPropertiesFile.exists()) {
             dimension "env"
             resValue "string", "package_name", "kr.co.causwv2.twa"
             resValue "string", "custom_url_scheme", "kr.co.causwv2.twa"
-            resValue "string", "kakao_native_app_key", "4535709d7c684cff31a42bb2b522eed9"
+            resValue "string", "kakao_native_app_key", kakaoNativeAppKeyProdRelease
+            resValue "string", "google_android_client_id", googleAndroidClientIdProdRelease
             resValue "string", "google_web_client_id", googleWebClientId
             manifestPlaceholders = [
                 appLabel: "크자회(CCSSAA)",
-                kakaoScheme: "kakao4535709d7c684cff31a42bb2b522eed9"
+                kakaoScheme: kakaoSchemeProdRelease
             ]
 
             versionCode 14
@@ -77,9 +85,10 @@ if (localPropertiesFile.exists()) {
 
     buildTypes {
         debug {
-            resValue "string", "kakao_native_app_key", "466439d207f1dc696c747e41d127d1d0"
+            resValue "string", "kakao_native_app_key", kakaoNativeAppKeyDebug
+            resValue "string", "google_android_client_id", googleAndroidClientIdDebug
             manifestPlaceholders = [
-                kakaoScheme: "kakao466439d207f1dc696c747e41d127d1d0"
+                kakaoScheme: kakaoSchemeDebug
             ]
         }
         release {

--- a/apps/web/android/app/build.gradle
+++ b/apps/web/android/app/build.gradle
@@ -30,6 +30,10 @@ if (localPropertiesFile.exists()) {
         localProperties.load(reader)
     }
 }
+    def googleWebClientId = localProperties.getProperty(
+        'googleWebClientId',
+        '1086770319771-hp040om1msg7r4o25u895b1pos47jkjt.apps.googleusercontent.com'
+    )
     signingConfigs {
         release {
             storeFile file(localProperties.getProperty('storeFile'))
@@ -47,21 +51,37 @@ if (localPropertiesFile.exists()) {
 
             resValue "string", "package_name", "kr.co.causwv2.twa.dev"
             resValue "string", "custom_url_scheme", "kr.co.causwv2.twa.dev"
-            manifestPlaceholders = [appLabel: "DEV-크자회"]
+            resValue "string", "kakao_native_app_key", "0d6f887e12de1e823fc6d021e90da922"
+            resValue "string", "google_web_client_id", googleWebClientId
+            manifestPlaceholders = [
+                appLabel: "DEV-크자회",
+                kakaoScheme: "kakao0d6f887e12de1e823fc6d021e90da922"
+            ]
 
-            versionCode 16
+            versionCode 20
         }
         prod {
             dimension "env"
             resValue "string", "package_name", "kr.co.causwv2.twa"
             resValue "string", "custom_url_scheme", "kr.co.causwv2.twa"
-            manifestPlaceholders = [appLabel: "크자회(CCSSAA)"]
+            resValue "string", "kakao_native_app_key", "4535709d7c684cff31a42bb2b522eed9"
+            resValue "string", "google_web_client_id", googleWebClientId
+            manifestPlaceholders = [
+                appLabel: "크자회(CCSSAA)",
+                kakaoScheme: "kakao4535709d7c684cff31a42bb2b522eed9"
+            ]
 
             versionCode 14
         }
     }
 
     buildTypes {
+        debug {
+            resValue "string", "kakao_native_app_key", "466439d207f1dc696c747e41d127d1d0"
+            manifestPlaceholders = [
+                kakaoScheme: "kakao466439d207f1dc696c747e41d127d1d0"
+            ]
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/apps/web/android/app/build.gradle
+++ b/apps/web/android/app/build.gradle
@@ -30,7 +30,7 @@ if (localPropertiesFile.exists()) {
         localProperties.load(reader)
     }
 }
-    def googleWebClientId = localProperties.getProperty('googleWebClientId')
+    def googleServerClientId = localProperties.getProperty('googleServerClientId')
     def googleAndroidClientIdDebug = localProperties.getProperty('googleAndroidClientIdDebug')
     def googleAndroidClientIdDevRelease = localProperties.getProperty('googleAndroidClientIdDevRelease')
     def googleAndroidClientIdProdRelease = localProperties.getProperty('googleAndroidClientIdProdRelease')
@@ -59,7 +59,7 @@ if (localPropertiesFile.exists()) {
             resValue "string", "custom_url_scheme", "kr.co.causwv2.twa.dev"
             resValue "string", "kakao_native_app_key", kakaoNativeAppKeyDevRelease
             resValue "string", "google_android_client_id", googleAndroidClientIdDevRelease
-            resValue "string", "google_web_client_id", googleWebClientId
+            resValue "string", "google_server_client_id", googleServerClientId
             manifestPlaceholders = [
                 appLabel: "DEV-크자회",
                 kakaoScheme: kakaoSchemeDevRelease
@@ -73,7 +73,7 @@ if (localPropertiesFile.exists()) {
             resValue "string", "custom_url_scheme", "kr.co.causwv2.twa"
             resValue "string", "kakao_native_app_key", kakaoNativeAppKeyProdRelease
             resValue "string", "google_android_client_id", googleAndroidClientIdProdRelease
-            resValue "string", "google_web_client_id", googleWebClientId
+            resValue "string", "google_server_client_id", googleServerClientId
             manifestPlaceholders = [
                 appLabel: "크자회(CCSSAA)",
                 kakaoScheme: kakaoSchemeProdRelease

--- a/apps/web/android/app/build.gradle
+++ b/apps/web/android/app/build.gradle
@@ -65,7 +65,7 @@ if (localPropertiesFile.exists()) {
                 kakaoScheme: kakaoSchemeDevRelease
             ]
 
-            versionCode 20
+            versionCode 21
         }
         prod {
             dimension "env"

--- a/apps/web/android/app/src/main/AndroidManifest.xml
+++ b/apps/web/android/app/src/main/AndroidManifest.xml
@@ -39,7 +39,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data
-                    android:scheme="kakao4535709d7c684cff31a42bb2b522eed9"
+                    android:scheme="${kakaoScheme}"
                     android:host="oauth" />
             </intent-filter>
         </activity>

--- a/apps/web/android/app/src/main/java/kr/co/causwv2/twa/MainActivity.java
+++ b/apps/web/android/app/src/main/java/kr/co/causwv2/twa/MainActivity.java
@@ -38,13 +38,13 @@ public class MainActivity extends BridgeActivity {
         safeAreaInsetsManager.setup();
 
         String kakaoNativeAppKey = getString(R.string.kakao_native_app_key);
-        String googleWebClientId = getString(R.string.google_web_client_id);
+        String googleServerClientId = getString(R.string.google_server_client_id);
         KakaoSdk.init(this, kakaoNativeAppKey);
 
         socialLoginCoordinator = new SocialLoginCoordinator(
             this,
             this::dispatchSocialLoginResult,
-            googleWebClientId
+            googleServerClientId
         );
 
         if (webView != null) {

--- a/apps/web/android/app/src/main/java/kr/co/causwv2/twa/SocialLoginCoordinator.java
+++ b/apps/web/android/app/src/main/java/kr/co/causwv2/twa/SocialLoginCoordinator.java
@@ -44,15 +44,15 @@ final class SocialLoginCoordinator {
 
     private final Activity activity;
     private final ResultDispatcher dispatcher;
-    private final String googleWebClientId;
+    private final String googleServerClientId;
 
     private String pendingGoogleRequestId = null;
     private GoogleSignInClient googleSignInClient = null;
 
-    SocialLoginCoordinator(Activity activity, ResultDispatcher dispatcher, String googleWebClientId) {
+    SocialLoginCoordinator(Activity activity, ResultDispatcher dispatcher, String googleServerClientId) {
         this.activity = activity;
         this.dispatcher = dispatcher;
-        this.googleWebClientId = googleWebClientId;
+        this.googleServerClientId = googleServerClientId;
     }
 
     private void dispatch(
@@ -182,7 +182,7 @@ final class SocialLoginCoordinator {
                     + ", packageName="
                     + activity.getPackageName()
                     + ", webClientId="
-                    + googleWebClientId
+                    + googleServerClientId
                     + ", requestId="
                     + requestId,
                 e
@@ -203,7 +203,7 @@ final class SocialLoginCoordinator {
                     + ", packageName="
                     + activity.getPackageName()
                     + ", webClientId="
-                    + googleWebClientId
+                    + googleServerClientId
                     + ", requestId="
                     + requestId,
                 e
@@ -377,7 +377,7 @@ final class SocialLoginCoordinator {
     }
 
     private void loginWithGoogle(String requestId) {
-        if (googleWebClientId == null || googleWebClientId.isEmpty()) {
+        if (googleServerClientId == null || googleServerClientId.isEmpty()) {
             dispatch(
                 "google",
                 requestId,
@@ -391,8 +391,8 @@ final class SocialLoginCoordinator {
 
         GoogleSignInOptions options = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
             .requestEmail()
-            .requestIdToken(googleWebClientId)
-            .requestServerAuthCode(googleWebClientId)
+            .requestIdToken(googleServerClientId)
+            .requestServerAuthCode(googleServerClientId)
             .build();
 
         googleSignInClient = GoogleSignIn.getClient(activity, options);

--- a/apps/web/android/app/src/main/res/values/strings.xml
+++ b/apps/web/android/app/src/main/res/values/strings.xml
@@ -1,5 +1,3 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
-    <string name="kakao_native_app_key">4535709d7c684cff31a42bb2b522eed9</string>
-    <string name="google_web_client_id">1086770319771-hp040om1msg7r4o25u895b1pos47jkjt.apps.googleusercontent.com</string>
 </resources>


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #203 


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 서명키에 따라 oauth의 client를 환경 별로 만들어줘야 했었는데, 해당 과정에서 prod, dev 에서의 서명키가 아닌 debug 환경에서만 쓸 수 있는 서명키를 활용해서 생긴 이슈 핸들링


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- google cloud console에서 각 환경에서의 서명키에 맞춰서 oauth client 운영, 개발, 로컬로 분리
- 카카오 개발자 콘솔에서 각 환경에서의 서명키에 맞춰서 oauth client 운영, 개발, 로컬로 분리
- 각 oauth client 변경에 따라서 달라진 oauth client id 값들을 운영, 개발, 로컬 환경에 맞춰서 매핑
- strings.xml에서의 client id 주입이 아닌, gradle에서 devDebug & prodDebug, devRelease, prodRelease 환경에 맞춰서 동적 매핑



## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.


## 📎 Additional Notes
-
