### PR TITLE
fix: 경조사 알림 타입 CEREMONY를 CEREMONY_V2로 변경

### DIFF
--- a/apps/web/src/entities/notification/config/notificationType.ts
+++ b/apps/web/src/entities/notification/config/notificationType.ts
@@ -9,8 +9,8 @@ export const NOTIFICATION_TYPE = {
     type: 'OFFICIAL',
     label: '공식계정 글 알림',
   },
-  CEREMONY: {
-    type: 'CEREMONY',
+  CEREMONY_V2: {
+    type: 'CEREMONY_V2',
     label: '경조사 알림',
   },
   SYSTEM: {

--- a/apps/web/src/entities/notification/lib/getNotificationPopupLink.ts
+++ b/apps/web/src/entities/notification/lib/getNotificationPopupLink.ts
@@ -12,7 +12,7 @@ export function getNotificationPopupLink(data: NotificationLatestResponse) {
       }
       return `${ROUTES.FEED}/${targetId}`;
 
-    case 'CEREMONY':
+    case 'CEREMONY_V2':
       return `${ROUTES.CEREMONY}/${targetId}`;
 
     case 'BOARD':

--- a/apps/web/src/entities/notification/mock/notificationMockDb.ts
+++ b/apps/web/src/entities/notification/mock/notificationMockDb.ts
@@ -27,7 +27,7 @@ const baseContent = [
     targetId: 'eaf2cafd-0726-4d51-b55c-f887b393ca13',
     targetParentId: '73247d42-da47-4a8c-86a6-2d4b0db23613',
     createdAt: '2026-03-06T00:28:07.444547',
-    noticeType: 'CEREMONY',
+    noticeType: 'CEREMONY_V2',
   },
   {
     notificationLogId: 'a60b4c6d-a140-4e0a-be33-f6b7e2213107',
@@ -63,7 +63,7 @@ const baseContent = [
     targetId: 'eaf2cafd-0726-4d51-b55c-f887b393ca13',
     targetParentId: '73247d42-da47-4a8c-86a6-2d4b0db23613',
     createdAt: '2026-03-02T01:31:56.3099',
-    noticeType: 'CEREMONY',
+    noticeType: 'CEREMONY_V2',
   },
   {
     notificationLogId: 'd78726e8-8966-434a-b168-139fcf01f2a8',
@@ -126,7 +126,7 @@ const baseContent = [
     targetId: 'b6f8253f-f045-4866-a253-943e3c3ad919',
     targetParentId: 'cf26d6f7-ef3d-452e-8b2c-081f19f752d2',
     createdAt: '2026-02-23T20:43:41.368632',
-    noticeType: 'CEREMONY',
+    noticeType: 'CEREMONY_V2',
   },
   {
     notificationLogId: '66439c46-20cd-4b2a-bcbc-867bfbafba99',
@@ -162,7 +162,7 @@ const baseContent = [
     targetId: 'b6f8253f-f045-4866-a253-943e3c3ad919',
     targetParentId: 'cf26d6f7-ef3d-452e-8b2c-081f19f752d2',
     createdAt: '2026-02-23T20:37:50.480154',
-    noticeType: 'CEREMONY',
+    noticeType: 'CEREMONY_V2',
   },
   {
     notificationLogId: '114ed498-2914-4e27-a898-51fffa34ed12',
@@ -180,7 +180,7 @@ const baseContent = [
     targetId: 'b6f8253f-f045-4866-a253-943e3c3ad919',
     targetParentId: 'cf26d6f7-ef3d-452e-8b2c-081f19f752d2',
     createdAt: '2026-02-14T23:46:28.553914',
-    noticeType: 'CEREMONY',
+    noticeType: 'CEREMONY_V2',
   },
 ];
 

--- a/apps/web/src/entities/notification/model/types/dto/getNotificationsDto.ts
+++ b/apps/web/src/entities/notification/model/types/dto/getNotificationsDto.ts
@@ -1,7 +1,7 @@
 /**
  * 커뮤니티, 공식, 시스템, 경조사 알림
  */
-type NotificationType = 'COMMUNITY' | 'OFFICIAL' | 'SYSTEM' | 'CEREMONY';
+type NotificationType = 'COMMUNITY' | 'OFFICIAL' | 'SYSTEM' | 'CEREMONY_V2';
 
 export interface GetNotificationsResponseDto {
   notificationLogId: string;

--- a/apps/web/src/entities/notification/model/types/types.ts
+++ b/apps/web/src/entities/notification/model/types/types.ts
@@ -13,7 +13,7 @@ export interface NotificationLatestResponse {
 export type NotificationType =
   | 'POST'
   | 'COMMENT'
-  | 'CEREMONY'
+  | 'CEREMONY_V2'
   | 'BOARD'
   | 'ADMISSION';
 

--- a/apps/web/src/features/notification/model/hooks/useNotificationListItem.ts
+++ b/apps/web/src/features/notification/model/hooks/useNotificationListItem.ts
@@ -28,7 +28,7 @@ export const useNotificationListItem = () => {
       return;
     }
 
-    if (notification.noticeType === NOTIFICATION_TYPE.CEREMONY.type) {
+    if (notification.noticeType === NOTIFICATION_TYPE.CEREMONY_V2.type) {
       router.push(`/ceremony/${notification.targetId}`);
       return;
     }


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #205


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 경조사 알림 타입 식별자를 백엔드 스펙 변경에 맞춰 `CEREMONY`에서 `CEREMONY_V2`로 일괄 수정


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- **타입 정의 업데이트**: `NotificationType` union 타입에서 `'CEREMONY'` → `'CEREMONY_V2'`로 변경 (`getNotificationsDto.ts`, `types.ts`)
- **설정 키 변경**: `NOTIFICATION_TYPE` 상수 객체의 `CEREMONY` 키 및 `type` 값을 `CEREMONY_V2`로 변경 (`notificationType.ts`)
- **라우팅 분기 수정**: `getNotificationPopupLink`의 switch-case와 `useNotificationListItem` 훅에서 경조사 타입 비교 로직 업데이트
- **Mock 데이터 동기화**: `notificationMockDb.ts`의 경조사 알림 5건의 `noticeType`을 `CEREMONY_V2`로 갱신


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- `CEREMONY_V2` 타입이 백엔드 API 응답 스펙과 정확히 일치하는지 확인
- `NOTIFICATION_TYPE` 상수를 참조하는 다른 코드에서 `CEREMONY` 키를 직접 사용하는 곳이 누락되지 않았는지 확인
- MSW mock 데이터가 실제 응답 형태와 일치하는지 검토


## 🧪 Test & Verification
- N/A (UI 컴포넌트 변경 없음 — 순수 타입/로직/설정 변경)

> 경조사 알림 수신 후 상세 페이지(`/ceremony/:id`)로 정상 이동하는지 수동 확인 권장


## 📎 Additional Notes
- 개발기간: 2026-05-06 ~ 2026-05-06
- 백엔드 알림 타입 스펙 변경(`CEREMONY` → `CEREMONY_V2`)에 대응하는 프론트엔드 동기화 작업
