### PR TITLE
[FEAT/#214] 게시글 검색어 삭제 시 최근 검색어 섹션 노출

### DIFF
--- a/apps/web/src/features/feed/model/hooks/useFeedSearchInput.ts
+++ b/apps/web/src/features/feed/model/hooks/useFeedSearchInput.ts
@@ -62,7 +62,10 @@ export const useFeedSearchInput = () => {
   };
 
   const handleTextInputChange = (event: ChangeEvent<HTMLInputElement>) => {
-    if (event.target.value.trim().length === 0) {
+    if (
+      event.target.value.trim().length === 0 &&
+      feedSearchKeyword.trim().length > 0
+    ) {
       removeFeedSearchKeyword();
       clearPendingSearchKeyword();
     }

--- a/apps/web/src/features/feed/model/hooks/useFeedSearchInput.ts
+++ b/apps/web/src/features/feed/model/hooks/useFeedSearchInput.ts
@@ -62,7 +62,7 @@ export const useFeedSearchInput = () => {
   };
 
   const handleTextInputChange = (event: ChangeEvent<HTMLInputElement>) => {
-    if (event.target.value.length === 0) {
+    if (event.target.value.trim().length === 0) {
       removeFeedSearchKeyword();
       clearPendingSearchKeyword();
     }

--- a/apps/web/src/features/feed/model/hooks/useFeedSearchInput.ts
+++ b/apps/web/src/features/feed/model/hooks/useFeedSearchInput.ts
@@ -62,6 +62,11 @@ export const useFeedSearchInput = () => {
   };
 
   const handleTextInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (event.target.value.length === 0) {
+      removeFeedSearchKeyword();
+      clearPendingSearchKeyword();
+    }
+
     setCurrentKeyword(event.target.value);
   };
 


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #214


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 게시글 검색어를 모두 지웠을 때 검색 결과를 초기화하고 최근 검색어 section이 다시 노출되도록 수정했습니다.


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- 검색 input 값이 비어 있거나 공백만 남은 경우 URL의 검색어 query param을 제거하도록 처리했습니다.
- 검색어 제거 시 pending search keyword도 함께 초기화해 검색 결과 section이 닫히고 최근 검색어 section이 노출되도록 했습니다.
- 검색어 길이 체크 기준을 trim 이후 값으로 맞춰 공백 입력 edge case를 보완했습니다.


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- 검색어를 전체 삭제하거나 공백만 남겼을 때 검색 결과가 초기화되고 최근 검색어 section이 노출되는지 확인해주세요.
- 검색어 입력 후 Enter 검색, 최근 검색어 chip 클릭, clear 버튼 클릭 흐름이 기존처럼 동작하는지 확인해주세요.


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.

- pnpm turbo lint --filter=@causw/web 실행 완료
- 결과: 0 errors, 6 warnings (기존 auth/shared 영역 warning)


## 📎 Additional Notes
- Ready for review 상태로 생성합니다.
