### PR TITLE
[FIX/#219] 동문수첩 목록 페이지 UI 깨짐 및 가로스크롤 문제 해결

### DIFF
--- a/apps/web/src/features/alumni-contacts/ui/alumni-contacts-academic-filter-sheet-modal-trigger/AlumniContactsAcademicFilterSheetModalTrigger.tsx
+++ b/apps/web/src/features/alumni-contacts/ui/alumni-contacts-academic-filter-sheet-modal-trigger/AlumniContactsAcademicFilterSheetModalTrigger.tsx
@@ -13,7 +13,7 @@ export const AlumniContactsAcademicFilterSheetModalTrigger = ({
     onClick?.();
   };
   return (
-    <Button asChild onClick={handleClick}>
+    <Button asChild onClick={handleClick} className="h-fit w-fit p-0">
       <HStack gap="sm" className="typo-body-15-medium items-center">
         <Chip color="white" size="md" className="cursor-pointer">
           학번 <ArrowDown size={14} color="gray-400" />

--- a/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-academic-filter-modal/AlumniContactsAcademicFilterModal.tsx
+++ b/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-academic-filter-modal/AlumniContactsAcademicFilterModal.tsx
@@ -15,7 +15,7 @@ export const AlumniContactsAcademicFilterModal = ({
 }: AlumniContactsAcademicFilterModalProps) => {
   return (
     <Modal open={open} onOpenChange={onOpenChange}>
-      <Modal.Title className="sr-only">
+      <Modal.Title className="sr-only w-0">
         동문 수첩 학번, 재학 상태 필터 선택 모달창
       </Modal.Title>
       <Modal.Content className="items-start p-6">

--- a/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-filter-group/AlumniContactsFilterGroup.tsx
+++ b/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-filter-group/AlumniContactsFilterGroup.tsx
@@ -26,7 +26,7 @@ export const AlumniContactsFilterGroup = () => {
   } = useAlumniContactsFilterGroup();
 
   return (
-    <HStack className="w-fit shrink-0 items-center overflow-x-auto">
+    <HStack className="shrink-0 items-center overflow-x-auto">
       <AlumniContactsSortFilterSelect />
       <div className="h-3 w-px shrink-0 bg-gray-300" />
       {filterActive ? (

--- a/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-filter-group/AlumniContactsFilterGroup.tsx
+++ b/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-filter-group/AlumniContactsFilterGroup.tsx
@@ -26,7 +26,7 @@ export const AlumniContactsFilterGroup = () => {
   } = useAlumniContactsFilterGroup();
 
   return (
-    <HStack className="-my-1 -ml-1 items-center overflow-x-auto py-1 pl-1">
+    <HStack className="w-fit shrink-0 items-center overflow-x-auto">
       <AlumniContactsSortFilterSelect />
       <div className="h-3 w-px shrink-0 bg-gray-300" />
       {filterActive ? (

--- a/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list-item/AlumniContactsListItem.tsx
+++ b/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list-item/AlumniContactsListItem.tsx
@@ -23,8 +23,11 @@ export const AlumniContactsListItem = ({
   });
 
   return (
-    <Link href={`/alumni-contacts/${item.id}`} key={item.id}>
-      <li className="flex h-27.5 min-w-0 gap-3 rounded-md bg-white px-4">
+    <li>
+      <Link
+        href={`/alumni-contacts/${item.id}`}
+        className="flex h-27.5 min-w-0 gap-3 rounded-md bg-white px-4"
+      >
         <HStack className="min-w-0 grow gap-5" align="center">
           <Avatar src={profileImageUrl} size={64} className="shrink-0" />
           <VStack gap="none" className="min-w-0 grow">
@@ -60,7 +63,7 @@ export const AlumniContactsListItem = ({
             className="shrink-0 self-center"
           />
         </HStack>
-      </li>
-    </Link>
+      </Link>
+    </li>
   );
 };

--- a/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list-item/AlumniContactsListItem.tsx
+++ b/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list-item/AlumniContactsListItem.tsx
@@ -24,10 +24,10 @@ export const AlumniContactsListItem = ({
 
   return (
     <Link href={`/alumni-contacts/${item.id}`} key={item.id}>
-      <li className="flex min-w-60 gap-3 rounded-md bg-white p-4">
-        <HStack className="grow gap-5">
+      <li className="flex h-27.5 min-w-0 gap-3 rounded-md bg-white px-4">
+        <HStack className="min-w-0 grow gap-5" align="center">
           <Avatar src={profileImageUrl} size={64} className="shrink-0" />
-          <VStack gap="none" className="grow">
+          <VStack gap="none" className="min-w-0 grow">
             <Text
               typography="subtitle-16-bold"
               textColor="gray-700"

--- a/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list-item/AlumniContactsListItem.tsx
+++ b/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list-item/AlumniContactsListItem.tsx
@@ -26,7 +26,7 @@ export const AlumniContactsListItem = ({
     <li>
       <Link
         href={`/alumni-contacts/${item.id}`}
-        className="flex h-27.5 min-w-0 gap-3 rounded-md bg-white px-4"
+        className="flex h-27.5 min-w-0 rounded-md bg-white px-4"
       >
         <HStack className="min-w-0 grow gap-5" align="center">
           <Avatar src={profileImageUrl} size={64} className="shrink-0" />

--- a/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list/AlumniContactsList.tsx
+++ b/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list/AlumniContactsList.tsx
@@ -46,7 +46,7 @@ const AlumniContactsList = ({
 }: AlumniContactsListProps) => {
   return (
     <ul
-      className="mb-20 grid min-h-0 grid-cols-1 gap-4 overflow-y-auto md:mb-5 md:grid-cols-2"
+      className="mb-20 grid min-h-0 flex-1 grid-cols-1 content-start gap-4 overflow-y-auto md:mb-5 md:grid-cols-2"
       ref={ref}
     >
       {data?.map((item) => (

--- a/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list/AlumniContactsList.tsx
+++ b/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list/AlumniContactsList.tsx
@@ -46,7 +46,7 @@ const AlumniContactsList = ({
 }: AlumniContactsListProps) => {
   return (
     <ul
-      className="mb-20 grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-y-auto md:mb-5 md:grid-cols-2"
+      className="mb-20 grid min-h-0 grid-cols-1 gap-4 overflow-y-auto md:mb-5 md:grid-cols-2"
       ref={ref}
     >
       {data?.map((item) => (


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #219


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 동문수첩 목록 페이지에서 검색 결과가 적을 때 UI가 깨지는 문제와 가로 스크롤 발생 문제를 해결했습니다.


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- 동문수첩 목록 grid 컨테이너의 `flex-1`을 제거해 결과 수가 적을 때 카드 row가 과도하게 늘어나지 않도록 수정했습니다.
- 목록 아이템의 `min-width` 기반 레이아웃을 정리하고 텍스트 영역에 `min-w-0`, `truncate`, `line-clamp`가 정상 동작하도록 조정했습니다.
- 목록 아이템 마크업을 `li > Link` 구조로 변경해 리스트 시맨틱과 클릭 영역 스타일 적용 위치를 개선했습니다.
- 필터 버튼/칩 영역의 불필요한 여백과 `w-fit`을 정리해 동문수첩 목록 페이지의 가로 스크롤 발생 가능성을 줄였습니다.
- 접근성용 `Modal.Title`에 `w-0`을 추가해 `sr-only` 제목이 모달의 가로 overflow를 유발하지 않도록 수정했습니다.


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- 동문수첩 목록 검색 결과가 적을 때 카드 높이와 row 간격이 자연스럽게 보이는지 확인해주세요.
- 모바일/좁은 viewport에서 동문수첩 목록 페이지에 의도하지 않은 가로 스크롤이 생기지 않는지 확인해주세요.
- 필터 칩 영역과 목록 아이템의 `min-w-0` 처리로 긴 이름/설명 텍스트가 정상적으로 말줄임되는지 확인해주세요.


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.

- `pnpm --filter @causw/web lint` 완료
  - 기존 warning 6건만 발생, 신규 error 없음
- `pnpm --filter @causw/web build` 완료


## 📎 Additional Notes
- Storybook 검증은 이번 변경 범위에서 별도로 수행하지 않았습니다.

