### PR TITLE
[FIX/#217] 게시글 상세에서 뒤로가기 시 목록 최상단으로 이동되는 문제 해결

### DIFF
--- a/apps/web/src/entities/feed/config/feedScrollRestorationStorageKey.ts
+++ b/apps/web/src/entities/feed/config/feedScrollRestorationStorageKey.ts
@@ -1,0 +1,5 @@
+export const FEED_SCROLL_RESTORATION_STORAGE_KEY = {
+  LIST: 'feed-scroll-restoration-list',
+  SEARCH: 'feed-scroll-restoration-search',
+  MY_FEED: 'feed-scroll-restoration-my-feed',
+};

--- a/apps/web/src/entities/feed/config/index.ts
+++ b/apps/web/src/entities/feed/config/index.ts
@@ -12,3 +12,4 @@ export {
   isMyFeedView,
   normalizeMyFeedView,
 } from './myFeedView';
+export { FEED_SCROLL_RESTORATION_STORAGE_KEY } from './feedScrollRestorationStorageKey';

--- a/apps/web/src/entities/feed/index.ts
+++ b/apps/web/src/entities/feed/index.ts
@@ -17,6 +17,7 @@ export {
   useFeedSearchKeyword,
   useMyFeedView,
   useFeedSearchPendingKeywordContext,
+  useGetFeedScrollRestorationStorageKey,
   type Board,
   type GetAvailableBoardListResponseDto,
 } from './model';

--- a/apps/web/src/entities/feed/model/hooks/index.ts
+++ b/apps/web/src/entities/feed/model/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useFeedSearchKeyword } from './useFeedSearchKeyword';
 export { useMyFeedView } from './useMyFeedView';
 export { useFeedSearchPendingKeywordContext } from './useFeedSearchPendingKeywordContext';
+export { useGetFeedScrollRestorationStorageKey } from './useGetFeedScrollRestorationStorageKey';

--- a/apps/web/src/entities/feed/model/hooks/useGetFeedScrollRestorationStorageKey.ts
+++ b/apps/web/src/entities/feed/model/hooks/useGetFeedScrollRestorationStorageKey.ts
@@ -1,0 +1,31 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { usePathname } from 'next/navigation';
+
+import { FEED_SCROLL_RESTORATION_STORAGE_KEY } from '../../config';
+
+export const useGetFeedScrollRestorationStorageKey = () => {
+  const pathname = usePathname();
+
+  const feedScrollRestorationStorageKey = useMemo(() => {
+    if (pathname.includes('/feed/search')) {
+      return FEED_SCROLL_RESTORATION_STORAGE_KEY.SEARCH;
+    }
+
+    if (pathname.includes('/feed')) {
+      return FEED_SCROLL_RESTORATION_STORAGE_KEY.LIST;
+    }
+
+    if (pathname.includes('/my-feed')) {
+      return FEED_SCROLL_RESTORATION_STORAGE_KEY.MY_FEED;
+    }
+
+    return '';
+  }, [pathname]);
+
+  return {
+    feedScrollRestorationStorageKey,
+  };
+};

--- a/apps/web/src/entities/feed/model/index.ts
+++ b/apps/web/src/entities/feed/model/index.ts
@@ -4,5 +4,6 @@ export {
   useFeedSearchKeyword,
   useMyFeedView,
   useFeedSearchPendingKeywordContext,
+  useGetFeedScrollRestorationStorageKey,
 } from './hooks';
 export { FeedSearchPendingKeywordContext } from './contexts';

--- a/apps/web/src/entities/post/config/query/postQueryOptions.ts
+++ b/apps/web/src/entities/post/config/query/postQueryOptions.ts
@@ -34,7 +34,7 @@ export const postQueryOptions = {
       initialPageParam: '',
       getNextPageParam: (lastPage) =>
         lastPage.nextCursor ? lastPage.nextCursor : undefined,
-      staleTime: QUERY_STALE_TIME.SHORT,
+      staleTime: QUERY_STALE_TIME.NONE,
       gcTime: QUERY_GC_TIME.LONG,
       throwOnError: true,
     }),
@@ -60,7 +60,7 @@ export const postQueryOptions = {
       initialPageParam: '',
       getNextPageParam: (lastPage) =>
         lastPage.nextCursor ? lastPage.nextCursor : undefined,
-      staleTime: QUERY_STALE_TIME.SHORT,
+      staleTime: QUERY_STALE_TIME.NONE,
       gcTime: QUERY_GC_TIME.LONG,
       throwOnError: true,
     }),

--- a/apps/web/src/entities/post/config/query/postQueryOptions.ts
+++ b/apps/web/src/entities/post/config/query/postQueryOptions.ts
@@ -2,7 +2,7 @@ import { infiniteQueryOptions, queryOptions } from '@tanstack/react-query';
 
 import { MY_FEED_VIEW, type MyFeedView } from '@/entities/feed';
 
-import { QUERY_STALE_TIME } from '@/shared/constants';
+import { QUERY_GC_TIME, QUERY_STALE_TIME } from '@/shared/constants';
 
 import {
   getMyCommentedPosts,
@@ -34,7 +34,8 @@ export const postQueryOptions = {
       initialPageParam: '',
       getNextPageParam: (lastPage) =>
         lastPage.nextCursor ? lastPage.nextCursor : undefined,
-      staleTime: QUERY_STALE_TIME.NONE,
+      staleTime: QUERY_STALE_TIME.SHORT,
+      gcTime: QUERY_GC_TIME.LONG,
       throwOnError: true,
     }),
 
@@ -59,7 +60,8 @@ export const postQueryOptions = {
       initialPageParam: '',
       getNextPageParam: (lastPage) =>
         lastPage.nextCursor ? lastPage.nextCursor : undefined,
-      staleTime: QUERY_STALE_TIME.NONE,
+      staleTime: QUERY_STALE_TIME.SHORT,
+      gcTime: QUERY_GC_TIME.LONG,
       throwOnError: true,
     }),
 };

--- a/apps/web/src/shared/hooks/index.ts
+++ b/apps/web/src/shared/hooks/index.ts
@@ -10,3 +10,4 @@ export * from './useLocalStorage';
 export * from './useEventListener';
 export * from './useEventCallback';
 export * from './useIsomorphicLayoutEffect';
+export * from './useSessionStorage';

--- a/apps/web/src/shared/hooks/useSessionStorage.ts
+++ b/apps/web/src/shared/hooks/useSessionStorage.ts
@@ -1,0 +1,166 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+
+import { useEventCallback } from './useEventCallback';
+import { useEventListener } from './useEventListener';
+
+declare global {
+  interface WindowEventMap {
+    'session-storage': CustomEvent;
+  }
+}
+
+type UseSessionStorageOptions<T> = {
+  serializer?: (value: T) => string;
+  deserializer?: (value: string) => T;
+  initializeWithValue?: boolean;
+};
+
+const IS_SERVER = typeof window === 'undefined';
+
+export function useSessionStorage<T>(
+  key: string,
+  initialValue: T | (() => T),
+  options: UseSessionStorageOptions<T> = {},
+): [T, Dispatch<SetStateAction<T>>, () => void] {
+  const { initializeWithValue = true } = options;
+
+  const serializer = useCallback<(value: T) => string>(
+    (value) => {
+      if (options.serializer) {
+        return options.serializer(value);
+      }
+
+      return JSON.stringify(value);
+    },
+    [options],
+  );
+
+  const deserializer = useCallback<(value: string) => T>(
+    (value) => {
+      if (options.deserializer) {
+        return options.deserializer(value);
+      }
+      // Support 'undefined' as a value
+      if (value === 'undefined') {
+        return undefined as unknown as T;
+      }
+
+      const defaultValue =
+        initialValue instanceof Function ? initialValue() : initialValue;
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(value);
+      } catch (error) {
+        console.error('Error parsing JSON:', error);
+        return defaultValue; // Return initialValue if parsing fails
+      }
+
+      return parsed as T;
+    },
+    [options, initialValue],
+  );
+
+  // Get from session storage then
+  // parse stored json or return initialValue
+  const readValue = useCallback((): T => {
+    const initialValueToUse =
+      initialValue instanceof Function ? initialValue() : initialValue;
+
+    // Prevent build error "window is undefined" but keep working
+    if (IS_SERVER) {
+      return initialValueToUse;
+    }
+
+    try {
+      const raw = window.sessionStorage.getItem(key);
+      return raw ? deserializer(raw) : initialValueToUse;
+    } catch (error) {
+      console.warn(`Error reading sessionStorage key “${key}”:`, error);
+      return initialValueToUse;
+    }
+  }, [initialValue, key, deserializer]);
+
+  const [storedValue, setStoredValue] = useState(() => {
+    if (initializeWithValue) {
+      return readValue();
+    }
+
+    return initialValue instanceof Function ? initialValue() : initialValue;
+  });
+
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to sessionStorage.
+  const setValue: Dispatch<SetStateAction<T>> = useEventCallback((value) => {
+    // Prevent build error "window is undefined" but keeps working
+    if (IS_SERVER) {
+      console.warn(
+        `Tried setting sessionStorage key “${key}” even though environment is not a client`,
+      );
+    }
+
+    try {
+      // Allow value to be a function so we have the same API as useState
+      const newValue = value instanceof Function ? value(readValue()) : value;
+
+      // Save to session storage
+      window.sessionStorage.setItem(key, serializer(newValue));
+
+      // Save state
+      setStoredValue(newValue);
+
+      // We dispatch a custom event so every similar useSessionStorage hook is notified
+      window.dispatchEvent(new StorageEvent('session-storage', { key }));
+    } catch (error) {
+      console.warn(`Error setting sessionStorage key “${key}”:`, error);
+    }
+  });
+
+  const removeValue = useEventCallback(() => {
+    // Prevent build error "window is undefined" but keeps working
+    if (IS_SERVER) {
+      console.warn(
+        `Tried removing sessionStorage key “${key}” even though environment is not a client`,
+      );
+    }
+
+    const defaultValue =
+      initialValue instanceof Function ? initialValue() : initialValue;
+
+    // Remove the key from session storage
+    window.sessionStorage.removeItem(key);
+
+    // Save state with default value
+    setStoredValue(defaultValue);
+
+    // We dispatch a custom event so every similar useSessionStorage hook is notified
+    window.dispatchEvent(new StorageEvent('session-storage', { key }));
+  });
+
+  useEffect(() => {
+    setStoredValue(readValue());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  const handleStorageChange = useCallback(
+    (event: StorageEvent | CustomEvent) => {
+      if ((event as StorageEvent).key && (event as StorageEvent).key !== key) {
+        return;
+      }
+      setStoredValue(readValue());
+    },
+    [key, readValue],
+  );
+
+  // this only works for other documents, not the current one
+  useEventListener('storage', handleStorageChange);
+
+  // this is a custom event, triggered in writeValueToSessionStorage
+  // See: useSessionStorage()
+  useEventListener('session-storage', handleStorageChange);
+
+  return [storedValue, setValue, removeValue];
+}

--- a/apps/web/src/widgets/feed/model/hooks/index.ts
+++ b/apps/web/src/widgets/feed/model/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useFeedMain } from './useFeedMain';
 export { useFeedRecentSearchKeywordSection } from './useFeedRecentSearchKeywordSection';
 export { usePostListItem } from './usePostListItem';
+export { useFeedScrollRestoration } from './useFeedScrollRestoration';

--- a/apps/web/src/widgets/feed/model/hooks/useFeedScrollRestoration.ts
+++ b/apps/web/src/widgets/feed/model/hooks/useFeedScrollRestoration.ts
@@ -38,6 +38,7 @@ export const useFeedScrollRestoration = ({
       (post) => post.postId === scrollRestorationTarget,
     );
 
+    // 게시글 캐시 데이터에 복원 대상 게시글이 없으면 초기화
     if (!scrollRestorationTarget || !hasScrollRestorationTarget) {
       removeScrollRestoration();
       return;

--- a/apps/web/src/widgets/feed/model/hooks/useFeedScrollRestoration.ts
+++ b/apps/web/src/widgets/feed/model/hooks/useFeedScrollRestoration.ts
@@ -1,0 +1,59 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { useGetFeedScrollRestorationStorageKey } from '@/entities/feed';
+import { type PostResponseDto } from '@/entities/post';
+
+import { useSessionStorage } from '@/shared/hooks';
+
+interface UseFeedScrollRestorationProps {
+  enabled?: boolean;
+  posts?: PostResponseDto[];
+}
+
+export const useFeedScrollRestoration = ({
+  enabled = false,
+  posts,
+}: UseFeedScrollRestorationProps) => {
+  const { feedScrollRestorationStorageKey } =
+    useGetFeedScrollRestorationStorageKey();
+
+  const [, , removeScrollRestoration] = useSessionStorage(
+    feedScrollRestorationStorageKey,
+    '',
+    {
+      initializeWithValue: false,
+    },
+  );
+
+  useEffect(() => {
+    if (!enabled || !posts) return;
+
+    const scrollRestorationTarget = sessionStorage
+      .getItem(feedScrollRestorationStorageKey)
+      ?.replaceAll('"', '');
+
+    const hasScrollRestorationTarget = posts.some(
+      (post) => post.postId === scrollRestorationTarget,
+    );
+
+    if (!scrollRestorationTarget || !hasScrollRestorationTarget) {
+      removeScrollRestoration();
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      document.getElementById(`${scrollRestorationTarget}`)?.scrollIntoView({
+        block: 'center',
+      });
+
+      removeScrollRestoration();
+    });
+  }, [
+    enabled,
+    removeScrollRestoration,
+    posts,
+    feedScrollRestorationStorageKey,
+  ]);
+};

--- a/apps/web/src/widgets/feed/model/hooks/useFeedScrollRestoration.ts
+++ b/apps/web/src/widgets/feed/model/hooks/useFeedScrollRestoration.ts
@@ -30,9 +30,13 @@ export const useFeedScrollRestoration = ({
   useEffect(() => {
     if (!enabled || !posts) return;
 
-    const scrollRestorationTarget = sessionStorage
-      .getItem(feedScrollRestorationStorageKey)
-      ?.replaceAll('"', '');
+    const rawScrollRestorationTarget = sessionStorage.getItem(
+      feedScrollRestorationStorageKey,
+    );
+
+    const scrollRestorationTarget = rawScrollRestorationTarget
+      ? JSON.parse(rawScrollRestorationTarget)
+      : null;
 
     const hasScrollRestorationTarget = posts.some(
       (post) => post.postId === scrollRestorationTarget,

--- a/apps/web/src/widgets/feed/model/hooks/usePostListItem.ts
+++ b/apps/web/src/widgets/feed/model/hooks/usePostListItem.ts
@@ -4,12 +4,27 @@ import { type KeyboardEvent, type MouseEvent } from 'react';
 
 import { useRouter } from 'next/navigation';
 
+import { useGetFeedScrollRestorationStorageKey } from '@/entities/feed';
 import { type PostResponseDto } from '@/entities/post';
+
+import { useSessionStorage } from '@/shared/hooks';
 
 export const usePostListItem = () => {
   const router = useRouter();
 
+  const { feedScrollRestorationStorageKey } =
+    useGetFeedScrollRestorationStorageKey();
+
+  const [, setScrollRestoration] = useSessionStorage(
+    feedScrollRestorationStorageKey,
+    '',
+    {
+      initializeWithValue: false,
+    },
+  );
+
   const moveToPost = (postId: PostResponseDto['postId']) => {
+    setScrollRestoration(postId);
     router.push(`/feed/${postId}`);
   };
 

--- a/apps/web/src/widgets/feed/model/index.ts
+++ b/apps/web/src/widgets/feed/model/index.ts
@@ -2,4 +2,5 @@ export {
   useFeedMain,
   useFeedRecentSearchKeywordSection,
   usePostListItem,
+  useFeedScrollRestoration,
 } from './hooks';

--- a/apps/web/src/widgets/feed/ui/feed-list-item/FeedListitem.tsx
+++ b/apps/web/src/widgets/feed/ui/feed-list-item/FeedListitem.tsx
@@ -38,7 +38,7 @@ export const FeedListitem = ({ post }: FeedListitemProps) => {
   const { handleCardClick, handleCardKeyDown } = usePostListItem();
 
   return (
-    <VStack className="relative">
+    <VStack className="relative" id={post.postId}>
       <VStack
         gap="sm"
         className="cursor-pointer rounded-lg bg-white p-4"

--- a/apps/web/src/widgets/feed/ui/feed-list/FeedListWrapper.tsx
+++ b/apps/web/src/widgets/feed/ui/feed-list/FeedListWrapper.tsx
@@ -14,6 +14,8 @@ import { postQueryOptions } from '@/entities/post';
 import { useBreakpoint, useInfiniteScroll } from '@/shared/hooks';
 import { SuspenseView } from '@/shared/ui';
 
+import { useFeedScrollRestoration } from '../../model';
+
 import { FeedList } from './FeedList';
 
 interface FeedListWrapperProps {
@@ -25,6 +27,7 @@ export const FeedListWrapper = ({ boardIds, ref }: FeedListWrapperProps) => {
   const {
     data: posts,
     isLoading,
+    isSuccess,
     isFetchingNextPage,
     hasNextPage,
     fetchNextPage,
@@ -41,6 +44,11 @@ export const FeedListWrapper = ({ boardIds, ref }: FeedListWrapperProps) => {
         fetchNextPage();
       }
     },
+  });
+
+  useFeedScrollRestoration({
+    enabled: isSuccess,
+    posts,
   });
 
   const { isMobileSize } = useBreakpoint();

--- a/apps/web/src/widgets/feed/ui/feed-search-result-list/FeedSearchResultList.tsx
+++ b/apps/web/src/widgets/feed/ui/feed-search-result-list/FeedSearchResultList.tsx
@@ -10,6 +10,7 @@ import { postQueryOptions } from '@/entities/post';
 import { useInfiniteScroll } from '@/shared/hooks';
 import { SuspenseView } from '@/shared/ui';
 
+import { useFeedScrollRestoration } from '../../model';
 import { FeedListitem } from '../feed-list-item';
 
 import { FeedSearchResultListEmptyView } from './FeedSearchResultListEmptyView';
@@ -25,6 +26,7 @@ export const FeedSearchResultList = () => {
   const {
     data: posts,
     isLoading,
+    isSuccess,
     isFetchingNextPage,
     hasNextPage,
     fetchNextPage,
@@ -44,6 +46,11 @@ export const FeedSearchResultList = () => {
         fetchNextPage();
       }
     },
+  });
+
+  useFeedScrollRestoration({
+    enabled: isSuccess,
+    posts,
   });
 
   if (!feedSearchKeyword) {

--- a/apps/web/src/widgets/feed/ui/my-feed-list/MyFeedList.tsx
+++ b/apps/web/src/widgets/feed/ui/my-feed-list/MyFeedList.tsx
@@ -12,6 +12,7 @@ import { postQueryOptions } from '@/entities/post';
 import { useInfiniteScroll } from '@/shared/hooks';
 import { SuspenseView } from '@/shared/ui';
 
+import { useFeedScrollRestoration } from '../../model';
 import { FeedListitem } from '../feed-list-item';
 
 import { MyFeedListEmptyView } from './MyFeedListEmptyView';
@@ -21,7 +22,7 @@ const MY_FEED_LIST_DEFAULT_SIZE = 20;
 export const MyFeedList = () => {
   const { myFeedView } = useMyFeedView();
 
-  const { data, isFetchingNextPage, hasNextPage, fetchNextPage } =
+  const { data, isFetchingNextPage, isSuccess, hasNextPage, fetchNextPage } =
     useSuspenseInfiniteQuery({
       ...postQueryOptions.myFeed(myFeedView, {
         size: MY_FEED_LIST_DEFAULT_SIZE,
@@ -48,6 +49,11 @@ export const MyFeedList = () => {
       });
     }
   }, [myFeedView]);
+
+  useFeedScrollRestoration({
+    enabled: isSuccess,
+    posts: data,
+  });
 
   if (data.length === 0) {
     return <MyFeedListEmptyView myFeedView={myFeedView} />;


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #217


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 게시글 상세 페이지에서 뒤로가기 시 이전에 보던 게시글 위치로 복원되도록 개선했습니다.


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- 게시글 목록별 스크롤 복원용 `sessionStorage` key와 조회 훅을 추가했습니다.
- `useSessionStorage` 훅을 추가해 세션 스토리지 값을 공통으로 관리할 수 있도록 했습니다.
- 게시글 목록 아이템에서 상세 페이지로 이동할 때 선택한 게시글 ID를 저장하도록 수정했습니다.
- 일반 피드, 검색 결과, 내 피드 목록에 스크롤 복원 훅을 연결해 캐시가 남아 있는 경우 이전 게시글 위치로 이동하도록 했습니다.
- 목록 쿼리의 `gcTime`을 늘려 상세 페이지 왕복 시 기존 목록 캐시가 유지되도록 조정했습니다.
- 복원 실패 시 최상단을 유지하는 현재 동작을 주석으로 명시했습니다.


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- 게시글 목록 종류별 저장 key 분리 방식이 적절한지
- 캐시가 유지된 경우에만 복원하고, 대상 게시글을 찾지 못하면 최상단을 유지하는 정책이 자연스러운지
- 공통 `useSessionStorage` 훅 도입 방식이 기존 훅 패턴과 잘 맞는지


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.

- 데스크탑 웹, 안드 환경에서 테스트했을 때는 문제 없이 동작했습니다

- 자동화 테스트는 별도로 실행하지 않았습니다.


## 📎 Additional Notes
- 캐시가 남아 있는 경우에만 이전 게시글 위치를 복원하며, 캐시가 없거나 현재 목록에서 대상 게시글을 찾지 못하면 목록 최상단을 유지합니다.
