### PR TITLE
[FEAT/#239] 동문수첩 목록 페이지 스크롤 복원 기능 추가

### DIFF
--- a/apps/web/src/entities/alumni-contacts/config/alumniContactsScrollRestorationStorageKey.ts
+++ b/apps/web/src/entities/alumni-contacts/config/alumniContactsScrollRestorationStorageKey.ts
@@ -1,0 +1,3 @@
+export const ALUMNI_CONTACTS_SCROLL_RESTORATION_STORAGE_KEY = {
+  LIST: 'alumni-contacts-list-scroll-restoration',
+};

--- a/apps/web/src/entities/alumni-contacts/config/index.ts
+++ b/apps/web/src/entities/alumni-contacts/config/index.ts
@@ -36,3 +36,4 @@ export {
   ALUMNI_CONTACTS_EDIT_FORM_MAX_LENGTH,
   ALUMNI_CONTACTS_EDIT_FORM_MAX_LIMIT,
 } from './alumniContactsEditFormLimit';
+export { ALUMNI_CONTACTS_SCROLL_RESTORATION_STORAGE_KEY } from './alumniContactsScrollRestorationStorageKey';

--- a/apps/web/src/entities/alumni-contacts/config/query/alumniContactsOptions.ts
+++ b/apps/web/src/entities/alumni-contacts/config/query/alumniContactsOptions.ts
@@ -22,6 +22,9 @@ export const alumniContactsQueryOptions = {
       initialPageParam: 0,
       getNextPageParam: (lastPage) =>
         lastPage.hasNext ? lastPage.currentPage + 1 : undefined,
+      staleTime: QUERY_STALE_TIME.NONE,
+      gcTime: QUERY_GC_TIME.LONG,
+      throwOnError: true,
     }),
   detail: (param: GetAlumniContactsDetailParam) =>
     queryOptions({

--- a/apps/web/src/entities/alumni-contacts/index.ts
+++ b/apps/web/src/entities/alumni-contacts/index.ts
@@ -22,6 +22,7 @@ export {
   ALUMNI_CONTACTS_EDIT_FORM_MAX_LENGTH,
   ALUMNI_CONTACTS_EDIT_FORM_MAX_LIMIT,
   ALUMNI_CONTACTS_URL_PREFIX,
+  ALUMNI_CONTACTS_SCROLL_RESTORATION_STORAGE_KEY,
 } from './config';
 export {
   AlumniContactsAcademicFilterSheetModalContext,
@@ -36,6 +37,7 @@ export {
   useAlumniContactsHeaderBoundaryContext,
   useWatchAlumniContactsEditFormField,
   type AlumniContactsDetail,
+  type AlumniContactsScrollRestorationState,
 } from './model';
 export {
   AlumniContactsAcademicFilterSheetModalProvider,

--- a/apps/web/src/entities/alumni-contacts/model/index.ts
+++ b/apps/web/src/entities/alumni-contacts/model/index.ts
@@ -15,5 +15,6 @@ export type {
   GetAlumniContactsDetailParam,
   GetMyAlumniContactsResponseDto,
   AlumniContactsDetail,
+  AlumniContactsScrollRestorationState,
 } from './types';
 export { alumniContactsEditSchema, type AlumniContactsEditForm } from './form';

--- a/apps/web/src/entities/alumni-contacts/model/types/alumniContactsScrollRestorationState.ts
+++ b/apps/web/src/entities/alumni-contacts/model/types/alumniContactsScrollRestorationState.ts
@@ -1,0 +1,6 @@
+import { type GetAlumniContactsQuery } from './query';
+
+export type AlumniContactsScrollRestorationState = {
+  alumniContactsId: string;
+  query: GetAlumniContactsQuery;
+};

--- a/apps/web/src/entities/alumni-contacts/model/types/index.ts
+++ b/apps/web/src/entities/alumni-contacts/model/types/index.ts
@@ -6,3 +6,4 @@ export type {
 } from './dto';
 export type { GetAlumniContactsDetailParam } from './param';
 export type { AlumniContactsDetail } from './alumniContactsDetail';
+export type { AlumniContactsScrollRestorationState } from './alumniContactsScrollRestorationState';

--- a/apps/web/src/shared/ui/index.ts
+++ b/apps/web/src/shared/ui/index.ts
@@ -17,3 +17,4 @@ export * from './IconCountButton';
 export * from './modal';
 export * from './header';
 export * from './profile-avatar';
+export * from './scroll-top-button';

--- a/apps/web/src/widgets/alumni-contacts/model/hooks/index.ts
+++ b/apps/web/src/widgets/alumni-contacts/model/hooks/index.ts
@@ -14,5 +14,5 @@ export { useAlumniContactsEditForm } from './useAlumniContactsEditForm';
 export { useAlumniContactsSingleFieldAddDialog } from './useAlumniContactsSingleFieldAddDialog';
 export { useAlumniContactsSingleFieldEditDialog } from './useAlumniContactsSingleFieldEditDialog';
 export { useAlumniContactsProfileEntryEditDialog } from './useAlumniContactsProfileEntryEditDialog';
-export { useAlumniContactsListItem } from './useAlumniContactsListItem';
 export { useAlumniContactsScrollRestoration } from './useAlumniContactsScrollRestoration';
+export { useAlumniContactsScrollSave } from './useAlumniContactsScrollSave';

--- a/apps/web/src/widgets/alumni-contacts/model/hooks/index.ts
+++ b/apps/web/src/widgets/alumni-contacts/model/hooks/index.ts
@@ -14,3 +14,5 @@ export { useAlumniContactsEditForm } from './useAlumniContactsEditForm';
 export { useAlumniContactsSingleFieldAddDialog } from './useAlumniContactsSingleFieldAddDialog';
 export { useAlumniContactsSingleFieldEditDialog } from './useAlumniContactsSingleFieldEditDialog';
 export { useAlumniContactsProfileEntryEditDialog } from './useAlumniContactsProfileEntryEditDialog';
+export { useAlumniContactsListItem } from './useAlumniContactsListItem';
+export { useAlumniContactsScrollRestoration } from './useAlumniContactsScrollRestoration';

--- a/apps/web/src/widgets/alumni-contacts/model/hooks/useAlumniContactsListItem.ts
+++ b/apps/web/src/widgets/alumni-contacts/model/hooks/useAlumniContactsListItem.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import {
+  ALUMNI_CONTACTS_SCROLL_RESTORATION_STORAGE_KEY,
+  type GetPaginatedAlumniContactsResponseDto,
+  type AlumniContactsScrollRestorationState,
+  type GetAlumniContactsQuery,
+} from '@/entities/alumni-contacts';
+
+import { useSessionStorage } from '@/shared/hooks';
+
+type AlumniContactsListItem =
+  GetPaginatedAlumniContactsResponseDto['content'][number];
+
+export const useAlumniContactsListItem = () => {
+  const [, setAlumniContactsScrollRestoration] =
+    useSessionStorage<AlumniContactsScrollRestorationState>(
+      ALUMNI_CONTACTS_SCROLL_RESTORATION_STORAGE_KEY.LIST,
+      {
+        alumniContactsId: '',
+        query: {},
+      },
+      {
+        initializeWithValue: false,
+      },
+    );
+
+  const handleNavigateToAlumniContacts = (
+    alumniContactsId: AlumniContactsListItem['id'],
+    query: GetAlumniContactsQuery,
+  ) => {
+    setAlumniContactsScrollRestoration({
+      alumniContactsId,
+      query,
+    });
+  };
+
+  return {
+    handleNavigateToAlumniContacts,
+  };
+};

--- a/apps/web/src/widgets/alumni-contacts/model/hooks/useAlumniContactsScrollRestoration.ts
+++ b/apps/web/src/widgets/alumni-contacts/model/hooks/useAlumniContactsScrollRestoration.ts
@@ -1,0 +1,118 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { type UseInfiniteQueryResult } from '@tanstack/react-query';
+import { isEqual } from 'es-toolkit';
+
+import {
+  ALUMNI_CONTACTS_SCROLL_RESTORATION_STORAGE_KEY,
+  type GetPaginatedAlumniContactsResponseDto,
+  type GetAlumniContactsQuery,
+} from '@/entities/alumni-contacts';
+
+interface UseAlumniContactsScrollRestorationProps {
+  data?: GetPaginatedAlumniContactsResponseDto['content'];
+  query: GetAlumniContactsQuery;
+  enabled?: boolean;
+  hasNextPage: boolean;
+  fetchNextPage: UseInfiniteQueryResult['fetchNextPage'];
+}
+
+export const useAlumniContactsScrollRestoration = ({
+  data,
+  query,
+  enabled = false,
+  hasNextPage,
+  fetchNextPage,
+}: UseAlumniContactsScrollRestorationProps) => {
+  const [isScrollRestoring, setIsScrollRestoring] = useState<boolean>(false);
+
+  const removeScrollRestoration = useCallback(() => {
+    sessionStorage.removeItem(
+      ALUMNI_CONTACTS_SCROLL_RESTORATION_STORAGE_KEY.LIST,
+    );
+  }, []);
+
+  const scrollToTargetAlumniContacts = useCallback(
+    (alumniContactsId: string) => {
+      requestAnimationFrame(() => {
+        document.getElementById(`${alumniContactsId}`)?.scrollIntoView({
+          block: 'center',
+        });
+      });
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const updateIsScrollRestoring = (isScrollRestoring: boolean) => {
+      setIsScrollRestoring(isScrollRestoring);
+    };
+
+    const resetScrollRestoration = () => {
+      removeScrollRestoration();
+      updateIsScrollRestoring(false);
+    };
+
+    updateIsScrollRestoring(true);
+
+    if (!enabled || !data) {
+      updateIsScrollRestoring(false);
+      return;
+    }
+
+    const rawScrollRestorationTarget = sessionStorage.getItem(
+      ALUMNI_CONTACTS_SCROLL_RESTORATION_STORAGE_KEY.LIST,
+    );
+
+    if (!rawScrollRestorationTarget) {
+      updateIsScrollRestoring(false);
+      return;
+    }
+
+    try {
+      const scrollRestorationTarget = JSON.parse(rawScrollRestorationTarget);
+
+      const isSameQuery = isEqual(scrollRestorationTarget.query, query);
+
+      // 같은 저장 상태가 아니라면 스크롤 복원 초기화
+      if (!isSameQuery) {
+        resetScrollRestoration();
+        return;
+      }
+
+      const hasScrollRestorationTarget = data.some(
+        (item) => item.id === scrollRestorationTarget.alumniContactsId,
+      );
+
+      if (hasScrollRestorationTarget) {
+        updateIsScrollRestoring(false);
+        scrollToTargetAlumniContacts(scrollRestorationTarget.alumniContactsId);
+        removeScrollRestoration();
+        return;
+      }
+
+      if (hasNextPage) {
+        fetchNextPage();
+        return;
+      }
+
+      resetScrollRestoration();
+    } catch {
+      resetScrollRestoration();
+    }
+  }, [
+    data,
+    query,
+    enabled,
+    removeScrollRestoration,
+    scrollToTargetAlumniContacts,
+    fetchNextPage,
+    hasNextPage,
+  ]);
+
+  return {
+    isScrollRestoring,
+  };
+};

--- a/apps/web/src/widgets/alumni-contacts/model/hooks/useAlumniContactsScrollRestoration.ts
+++ b/apps/web/src/widgets/alumni-contacts/model/hooks/useAlumniContactsScrollRestoration.ts
@@ -55,13 +55,11 @@ export const useAlumniContactsScrollRestoration = ({
       updateIsScrollRestoring(false);
     };
 
-    updateIsScrollRestoring(true);
-
     if (!enabled || !data) {
-      updateIsScrollRestoring(false);
       return;
     }
 
+    updateIsScrollRestoring(true);
     const rawScrollRestorationTarget = sessionStorage.getItem(
       ALUMNI_CONTACTS_SCROLL_RESTORATION_STORAGE_KEY.LIST,
     );

--- a/apps/web/src/widgets/alumni-contacts/model/hooks/useAlumniContactsScrollSave.ts
+++ b/apps/web/src/widgets/alumni-contacts/model/hooks/useAlumniContactsScrollSave.ts
@@ -12,7 +12,7 @@ import { useSessionStorage } from '@/shared/hooks';
 type AlumniContactsListItem =
   GetPaginatedAlumniContactsResponseDto['content'][number];
 
-export const useAlumniContactsListItem = () => {
+export const useAlumniContactsScrollSave = () => {
   const [, setAlumniContactsScrollRestoration] =
     useSessionStorage<AlumniContactsScrollRestorationState>(
       ALUMNI_CONTACTS_SCROLL_RESTORATION_STORAGE_KEY.LIST,

--- a/apps/web/src/widgets/alumni-contacts/model/index.ts
+++ b/apps/web/src/widgets/alumni-contacts/model/index.ts
@@ -15,6 +15,8 @@ export {
   useAlumniContactsSingleFieldAddDialog,
   useAlumniContactsSingleFieldEditDialog,
   useAlumniContactsProfileEntryEditDialog,
+  useAlumniContactsListItem,
+  useAlumniContactsScrollRestoration,
 } from './hooks';
 export { sortAlumniContactsProfileEntry } from './sortAlumniContactsProfileEntry';
 export { createAlumniContactsProfileEntry } from './createAlumniContactsProfileEntry';

--- a/apps/web/src/widgets/alumni-contacts/model/index.ts
+++ b/apps/web/src/widgets/alumni-contacts/model/index.ts
@@ -15,8 +15,8 @@ export {
   useAlumniContactsSingleFieldAddDialog,
   useAlumniContactsSingleFieldEditDialog,
   useAlumniContactsProfileEntryEditDialog,
-  useAlumniContactsListItem,
   useAlumniContactsScrollRestoration,
+  useAlumniContactsScrollSave,
 } from './hooks';
 export { sortAlumniContactsProfileEntry } from './sortAlumniContactsProfileEntry';
 export { createAlumniContactsProfileEntry } from './createAlumniContactsProfileEntry';

--- a/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list-item/AlumniContactsListItem.tsx
+++ b/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list-item/AlumniContactsListItem.tsx
@@ -1,20 +1,29 @@
+'use client';
+
 import Link from 'next/link';
 
 import { Avatar, ChevronRight, HStack, Text, VStack } from '@causw/cds';
 
-import type { GetPaginatedAlumniContactsResponseDto } from '@/entities/alumni-contacts';
+import {
+  type GetAlumniContactsQuery,
+  type GetPaginatedAlumniContactsResponseDto,
+} from '@/entities/alumni-contacts';
 
 import { getProfileImageUrl } from '@/shared/lib';
+
+import { useAlumniContactsListItem } from '../../model';
 
 type AlumniContactsListItem =
   GetPaginatedAlumniContactsResponseDto['content'][number];
 
 interface AlumniContactsListItemProps {
   item: AlumniContactsListItem;
+  query: GetAlumniContactsQuery;
 }
 
 export const AlumniContactsListItem = ({
   item,
+  query,
 }: AlumniContactsListItemProps) => {
   const profileImageUrl = getProfileImageUrl({
     profileImageType: item.profileImage.profileImageType,
@@ -22,10 +31,13 @@ export const AlumniContactsListItem = ({
     width: 64,
   });
 
+  const { handleNavigateToAlumniContacts } = useAlumniContactsListItem();
+
   return (
-    <li>
+    <li id={item.id}>
       <Link
         href={`/alumni-contacts/${item.id}`}
+        onNavigate={() => handleNavigateToAlumniContacts(item.id, query)}
         className="flex h-27.5 min-w-0 rounded-md bg-white px-4"
       >
         <HStack className="min-w-0 grow gap-5" align="center">

--- a/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list-item/AlumniContactsListItem.tsx
+++ b/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list-item/AlumniContactsListItem.tsx
@@ -11,19 +11,22 @@ import {
 
 import { getProfileImageUrl } from '@/shared/lib';
 
-import { useAlumniContactsListItem } from '../../model';
-
 type AlumniContactsListItem =
   GetPaginatedAlumniContactsResponseDto['content'][number];
 
 interface AlumniContactsListItemProps {
   item: AlumniContactsListItem;
   query: GetAlumniContactsQuery;
+  onNavigate: (
+    alumniContactsId: AlumniContactsListItem['id'],
+    query: GetAlumniContactsQuery,
+  ) => void;
 }
 
 export const AlumniContactsListItem = ({
   item,
   query,
+  onNavigate,
 }: AlumniContactsListItemProps) => {
   const profileImageUrl = getProfileImageUrl({
     profileImageType: item.profileImage.profileImageType,
@@ -31,13 +34,11 @@ export const AlumniContactsListItem = ({
     width: 64,
   });
 
-  const { handleNavigateToAlumniContacts } = useAlumniContactsListItem();
-
   return (
     <li id={item.id}>
       <Link
         href={`/alumni-contacts/${item.id}`}
-        onNavigate={() => handleNavigateToAlumniContacts(item.id, query)}
+        onNavigate={() => onNavigate(item.id, query)}
         className="flex h-27.5 min-w-0 rounded-md bg-white px-4"
       >
         <HStack className="min-w-0 grow gap-5" align="center">

--- a/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list/AlumniContactsList.tsx
+++ b/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list/AlumniContactsList.tsx
@@ -11,24 +11,28 @@ import { PullToRefresh } from '@causw/cds';
 import {
   AlumniContactsFilterSearchParam,
   alumniContactsQueryOptions,
+  type GetAlumniContactsQuery,
   type GetPaginatedAlumniContactsResponseDto,
 } from '@/entities/alumni-contacts';
 
-import { QUERY_STALE_TIME } from '@/shared/constants';
 import { useBreakpoint, useInfiniteScroll } from '@/shared/hooks';
-import { SuspenseView } from '@/shared/ui';
-import { ScrollTopButton } from '@/shared/ui/scroll-top-button';
+import { ScrollTopButton, SuspenseView } from '@/shared/ui';
 
-import { useAlumniContactsListScrollTop } from '../../model';
+import {
+  useAlumniContactsListScrollTop,
+  useAlumniContactsScrollRestoration,
+} from '../../model';
 import { AlumniContactsListItem } from '../alumni-contacts-list-item';
 
 import { AlumniContactsListEmptyView } from './AlumniContactsListEmptyView';
+import { AlumniContactsListLoadingView } from './AlumniContactsListLoadingView';
 
 type AlumniContactsListItem =
   GetPaginatedAlumniContactsResponseDto['content'][number];
 
 interface AlumniContactsListProps {
   data?: AlumniContactsListItem[];
+  query: GetAlumniContactsQuery;
   isLoading: boolean;
   isFetchingNextPage: boolean;
   hasNextPage: boolean;
@@ -38,6 +42,7 @@ interface AlumniContactsListProps {
 
 const AlumniContactsList = ({
   data,
+  query,
   isLoading,
   isFetchingNextPage,
   hasNextPage,
@@ -50,7 +55,7 @@ const AlumniContactsList = ({
       ref={ref}
     >
       {data?.map((item) => (
-        <AlumniContactsListItem key={item.id} item={item} />
+        <AlumniContactsListItem key={item.id} item={item} query={query} />
       ))}
       {!isLoading && !isFetchingNextPage && hasNextPage && (
         <div ref={targetRef} className="h-3 w-full" />
@@ -76,13 +81,13 @@ export const AlumniContactsListWrapper = () => {
   const {
     data,
     isLoading,
+    isSuccess,
     isFetchingNextPage,
     hasNextPage,
     fetchNextPage,
     refetch,
   } = useInfiniteQuery({
     ...alumniContactsQueryOptions.list(query),
-    staleTime: QUERY_STALE_TIME.NONE,
     select: (data) => data.pages.flatMap((page) => page.content),
   });
 
@@ -102,8 +107,20 @@ export const AlumniContactsListWrapper = () => {
     handleClickScrollTop,
   } = useAlumniContactsListScrollTop();
 
+  const { isScrollRestoring } = useAlumniContactsScrollRestoration({
+    data,
+    query,
+    enabled: isSuccess,
+    hasNextPage,
+    fetchNextPage,
+  });
+
   if (!data || data?.length === 0) {
     return <AlumniContactsListEmptyView />;
+  }
+
+  if (isScrollRestoring) {
+    return <AlumniContactsListLoadingView />;
   }
 
   if (isMobileSize) {
@@ -117,6 +134,7 @@ export const AlumniContactsListWrapper = () => {
         >
           <AlumniContactsList
             data={data}
+            query={query}
             isLoading={isLoading}
             isFetchingNextPage={isFetchingNextPage}
             hasNextPage={hasNextPage}
@@ -135,6 +153,7 @@ export const AlumniContactsListWrapper = () => {
     <>
       <AlumniContactsList
         data={data}
+        query={query}
         isLoading={isLoading}
         isFetchingNextPage={isFetchingNextPage}
         hasNextPage={hasNextPage}

--- a/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list/AlumniContactsList.tsx
+++ b/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list/AlumniContactsList.tsx
@@ -21,6 +21,7 @@ import { ScrollTopButton, SuspenseView } from '@/shared/ui';
 import {
   useAlumniContactsListScrollTop,
   useAlumniContactsScrollRestoration,
+  useAlumniContactsScrollSave,
 } from '../../model';
 import { AlumniContactsListItem } from '../alumni-contacts-list-item';
 
@@ -49,13 +50,20 @@ const AlumniContactsList = ({
   targetRef,
   ref,
 }: AlumniContactsListProps) => {
+  const { handleNavigateToAlumniContacts } = useAlumniContactsScrollSave();
+
   return (
     <ul
       className="mb-20 grid min-h-0 flex-1 grid-cols-1 content-start gap-4 overflow-y-auto md:mb-5 md:grid-cols-2"
       ref={ref}
     >
       {data?.map((item) => (
-        <AlumniContactsListItem key={item.id} item={item} query={query} />
+        <AlumniContactsListItem
+          key={item.id}
+          item={item}
+          query={query}
+          onNavigate={handleNavigateToAlumniContacts}
+        />
       ))}
       {!isLoading && !isFetchingNextPage && hasNextPage && (
         <div ref={targetRef} className="h-3 w-full" />


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #239


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 동문수첩 목록 페이지에서 상세 페이지 방문 후 이전 탐색 위치로 돌아갈 수 있도록 스크롤 복원 기능을 추가했습니다.


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- 동문수첩 목록 스크롤 복원에 사용할 sessionStorage key와 state type을 추가했습니다.
- 목록 데이터가 복원 흐름에 활용될 수 있도록 query의 `staleTime`, `gcTime` 설정을 조정했습니다.
- 상세 페이지 이동 시 복원 대상 동문 정보와 현재 query를 저장하고, 목록 복귀 시 대상 항목이 로드될 때까지 추가 페이지를 조회한 뒤 해당 위치로 스크롤하도록 구현했습니다.
- 관련 hook과 shared UI export를 정리했습니다.


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- 필터 query가 동일한 경우에만 스크롤 복원이 수행되는지
- 복원 대상이 현재 캐시에 없을 때 추가 페이지 조회 후 자연스럽게 위치가 복원되는지
- 모바일/데스크톱 목록 UI에서 복원 중 로딩 처리와 스크롤 이동이 자연스러운지


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.

- 수동으로 동문수첩 목록에서 상세 페이지 진입 후 목록 복귀 시 스크롤 복원 동작을 확인했습니다.


## 📎 Additional Notes
- 게시글 목록 스크롤 복원 구현 흐름을 참고해 동문수첩 목록 특성에 맞게 확장했습니다.
