### PR TITLE
[FIX/#229] 알림 설정 화면 하단 잘림 해결

### DIFF
--- a/apps/web/src/_pages/notification/NotificationPage.tsx
+++ b/apps/web/src/_pages/notification/NotificationPage.tsx
@@ -11,7 +11,10 @@ import {
 export function NotificationPage() {
   return (
     <div className="flex w-full justify-center">
-      <VStack gap="sm" className="w-full max-w-225 md:px-8 md:py-6">
+      <VStack
+        gap="sm"
+        className="w-full max-w-225 pb-[calc(env(safe-area-inset-bottom)+16px)] md:px-8 md:py-6"
+      >
         <NotificationListActionHeader />
         <Suspense fallback={<NotificationListSectionLoadingView />}>
           <NotificationListSectionServerComponent />

--- a/apps/web/src/_pages/notification/NotificationPage.tsx
+++ b/apps/web/src/_pages/notification/NotificationPage.tsx
@@ -11,10 +11,7 @@ import {
 export function NotificationPage() {
   return (
     <div className="flex w-full justify-center">
-      <VStack
-        gap="sm"
-        className="w-full max-w-225 pb-[calc(env(safe-area-inset-bottom)+16px)] md:px-8 md:py-6"
-      >
+      <VStack gap="sm" className="w-full max-w-225 pb-4 md:px-8 md:py-6">
         <NotificationListActionHeader />
         <Suspense fallback={<NotificationListSectionLoadingView />}>
           <NotificationListSectionServerComponent />

--- a/apps/web/src/_pages/setting/notifications/SettingNotificationsPage.tsx
+++ b/apps/web/src/_pages/setting/notifications/SettingNotificationsPage.tsx
@@ -73,10 +73,7 @@ const SettingNotificationContent = () => {
   }, []);
 
   return (
-    <VStack
-      gap="md"
-      className="w-full px-4 pb-[calc(env(safe-area-inset-bottom)+16px)]"
-    >
+    <VStack gap="md" className="w-full px-4 pb-4">
       <Text typography="title-22-bold">{SETTING_NOTIFICATIONS.title}</Text>
       {isPushNotificationDenied && <PushNotificationPermissionNotice />}
       <CommunityNotificationSection

--- a/apps/web/src/_pages/setting/notifications/SettingNotificationsPage.tsx
+++ b/apps/web/src/_pages/setting/notifications/SettingNotificationsPage.tsx
@@ -73,7 +73,10 @@ const SettingNotificationContent = () => {
   }, []);
 
   return (
-    <VStack gap="md" className="w-full px-4">
+    <VStack
+      gap="md"
+      className="w-full px-4 pb-[calc(env(safe-area-inset-bottom)+16px)]"
+    >
       <Text typography="title-22-bold">{SETTING_NOTIFICATIONS.title}</Text>
       {isPushNotificationDenied && <PushNotificationPermissionNotice />}
       <CommunityNotificationSection


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #229 


## ✨ Summary

- 알림 페이지, 알림 설정 페이지 하단 패딩을 추가했습니다


## 📚 Details of Changes

- 알림 목록 화면 하단에 safe-area를 고려한 padding-bottom을 추가했습니다.
- 알림 설정 화면 하단에 safe-area를 고려한 padding-bottom을 추가했습니다.


## 🎯 Key points to review

- 앱에서 알림 목록/알림 설정 화면 하단이 정상적으로 노출되는지 확인 부탁드립니다.
- 웹 화면에서 기존 레이아웃에 영향이 없는지 확인 부탁드립니다.

## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

<img width="200" height="500" alt="스크린샷 2026-05-17 230052" src="https://github.com/user-attachments/assets/764e1f1c-7389-4be7-90f0-cbaa35cacb41" />