### PR TITLE
[FIX/#234] 이메일 찾기 결과 화면 전환 오류 bug 버그 수정

### DIFF
--- a/apps/web/src/entities/auth/model/types/types.ts
+++ b/apps/web/src/entities/auth/model/types/types.ts
@@ -128,13 +128,14 @@ export type SocialProvider = 'KAKAO' | 'APPLE' | 'GOOGLE';
 
 export interface SocialAccountSummary {
   provider: SocialProvider;
-  createdAt: string;
+  createdAt?: string | null;
+  onboardingStatus?: OnboardingStatus;
 }
 
 export interface EmailFindResponse {
-  email: string;
-  createdAt: string;
-  socialAccounts: SocialAccountSummary[];
+  email?: string | null;
+  createdAt?: string | null;
+  socialAccounts?: SocialAccountSummary[] | null;
 }
 
 export interface PasswordResetSendRequestDto {

--- a/apps/web/src/widgets/auth/ui/find-account-container/FindAccountContainer.tsx
+++ b/apps/web/src/widgets/auth/ui/find-account-container/FindAccountContainer.tsx
@@ -34,6 +34,19 @@ interface FindAccountContainerProps {
   onViewChange: (view: FindAccountView) => void;
 }
 
+const normalizeFindEmailFormData = (formData: FindEmailFormData) => ({
+  name: formData.name.replace(/\s/g, ''),
+  phoneNumber: formData.phoneNumber.trim(),
+});
+
+const hasFindEmailResult = (
+  data: EmailFindResponse | null | undefined,
+): data is EmailFindResponse => {
+  if (!data) return false;
+
+  return !!data.email?.trim() || (data.socialAccounts?.length ?? 0) > 0;
+};
+
 export const FindAccountContainer = ({
   view,
   onViewChange,
@@ -52,9 +65,16 @@ export const FindAccountContainer = ({
   };
 
   const handleFindEmail = (formData: FindEmailFormData) => {
-    findEmailMutation.mutate(formData, {
+    const normalizedFormData = normalizeFindEmailFormData(formData);
+
+    findEmailMutation.mutate(normalizedFormData, {
       onSuccess: (data) => {
-        onViewChange({ type: 'result', data, name: formData.name });
+        if (!hasFindEmailResult(data)) {
+          onViewChange({ type: 'not-found' });
+          return;
+        }
+
+        onViewChange({ type: 'result', data, name: normalizedFormData.name });
       },
       onError: (error) => {
         if (error instanceof ApiError && error.status && error.status < 500) {

--- a/apps/web/src/widgets/auth/ui/find-email-not-found/FindEmailNotFound.tsx
+++ b/apps/web/src/widgets/auth/ui/find-email-not-found/FindEmailNotFound.tsx
@@ -31,7 +31,8 @@ export const FindEmailNotFound = ({ onRetry }: FindEmailNotFoundProps) => {
             </Text>
             <Text typography="body-15-regular" textColor="gray-500">
               입력하신 정보(이름, 전화번호)에 오타가 없는지 다시 한번 확인해
-              주세요.
+              주세요. 소셜 가입을 완료하지 않은 계정은 추가 정보를 입력한 뒤
+              다시 이용할 수 있어요.
             </Text>
           </VStack>
         </VStack>

--- a/apps/web/src/widgets/auth/ui/find-email-result/FindEmailResult.tsx
+++ b/apps/web/src/widgets/auth/ui/find-email-result/FindEmailResult.tsx
@@ -44,8 +44,14 @@ const SOCIAL_ICON_MAP: Record<
   },
 };
 
-const formatDate = (dateStr: string) => {
+const formatDate = (dateStr?: string | null) => {
+  if (!dateStr) return '-';
+
   return dateStr.replace(/-/g, '. ');
+};
+
+const getSocialProvider = (provider: SocialProvider) => {
+  return SOCIAL_ICON_MAP[provider] ?? { icon: null, label: provider };
 };
 
 interface FindEmailResultProps {
@@ -61,8 +67,12 @@ export const FindEmailResult = ({
 }: FindEmailResultProps) => {
   const router = useRouter();
 
-  const hasEmail = !!data.email;
-  const hasSocial = data.socialAccounts.length > 0;
+  const email = data.email?.trim();
+  const socialAccounts = Array.isArray(data.socialAccounts)
+    ? data.socialAccounts
+    : [];
+  const hasEmail = !!email;
+  const hasSocial = socialAccounts.length > 0;
 
   return (
     <VStack className="w-full gap-10">
@@ -83,7 +93,7 @@ export const FindEmailResult = ({
                 이메일
               </Text>
               <Text typography="subtitle-16-bold" textColor="gray-700">
-                {data.email}
+                {email}
               </Text>
             </HStack>
             <HStack className="items-center justify-between">
@@ -107,17 +117,18 @@ export const FindEmailResult = ({
               연동된 소셜 계정
             </Text>
             <VStack className="gap-5 rounded-[1rem] bg-white p-5">
-              {data.socialAccounts.map((account) => {
-                const social = SOCIAL_ICON_MAP[account.provider];
+              {socialAccounts.map((account, index) => {
+                const social = getSocialProvider(account.provider);
                 return (
                   <HStack
-                    key={`${account.provider}-${account.createdAt}`}
+                    key={`${account.provider}-${account.createdAt ?? index}`}
                     className="items-center gap-3"
                   >
                     {social.icon}
                     <Text typography="body-14-regular" textColor="gray-600">
                       {social.label} 연동 계정 (가입일:{' '}
                       {formatDate(account.createdAt)})
+                      {account.onboardingStatus === 'GUEST' && ' - 가입 미완료'}
                     </Text>
                   </HStack>
                 );


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #234 


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 이메일 찾기 성공 후 결과 응답 형태에 따라 오류 화면으로 전환되던 문제를 수정했습니다.


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- 이메일 찾기 결과 응답의 `email`, `createdAt`, `socialAccounts` nullable 케이스를 안전하게 처리했습니다.
- 이름 입력값의 공백을 제거한 뒤 이메일 찾기 API를 요청하도록 수정했습니다.
- 성공 응답이지만 표시할 계정 정보가 없는 경우 오류 화면 대신 안내 화면으로 전환하도록 처리했습니다.
- 소셜 가입 미완료 계정 가능성을 not-found 안내 문구에 반영했습니다.


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- `email=null`, `socialAccounts=null/undefined/[]` 응답에서 결과 화면이 정상 처리되는지
- 이름 중간 공백 입력 시 계정 조회가 정상 동작하는지
- 미완료 소셜 가입 계정 케이스의 안내 문구가 적절한지


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.

https://github.com/user-attachments/assets/644c3e3b-d0c0-4f0a-93c5-48ef78d2857d

https://github.com/user-attachments/assets/e110998c-8853-4be5-80df-3a968cf9caba


## 📎 Additional Notes
-
