### PR TITLE
[FIX/#231] 크롤링 게시글 본문 레이아웃 깨지는 문제 및 작성 시간 오류 해결

### DIFF
--- a/apps/web/src/entities/post/ui/PostBody.tsx
+++ b/apps/web/src/entities/post/ui/PostBody.tsx
@@ -81,6 +81,7 @@ export const PostBody = ({
             dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
             suppressHydrationWarning
             style={collapseStyles}
+            className="break-all [&_a]:break-all [&_img]:h-auto [&_img]:max-w-full"
           />
         ) : (
           <Text
@@ -88,7 +89,7 @@ export const PostBody = ({
             as="p"
             typography="body-16-regular"
             textColor="gray-800"
-            className="whitespace-pre-wrap"
+            className="break-all whitespace-pre-wrap"
             style={collapseStyles}
           >
             {content}

--- a/apps/web/src/shared/lib/format/date.ts
+++ b/apps/web/src/shared/lib/format/date.ts
@@ -70,7 +70,7 @@ export const formatRelativeTime = (time: string | Date) => {
   const diffSeconds = Math.floor((now.getTime() - date.getTime()) / 1000);
   const absDiff = Math.abs(diffSeconds);
 
-  const isFuture = diffSeconds < 0;
+  const isFuture = diffSeconds < -5;
 
   if (absDiff < 60) {
     return isFuture ? '잠시 후' : '방금 전';


### PR DESCRIPTION
# 🚀 Pull Request

## Issue

- Closes #231 


## ✨ Summary

일부 게시글 본문에서 가로 스크롤이 발생하는/레이아웃이 깨지는 이슈가
크롤링 게시글 등에서 html이 인라인 스타일로 너비를 고정하고 있어 발생하는 문제임을 확인하여 본문 스타일을 일부 수정했고,

서버/클라이언트 간 미세한 시간 오차로 인해 일부 작성 시간이 '잠시 후'로 나오는 문제를 해결하기 위해 
상대 시간 계산 로직에 5초의 허용치를 두었습니다.

## 📚 Details of Changes

- PostBody 컴포넌트의 텍스트 스타일에 `break-all` 추가
- 상대 시간 계산 로직 수정


## 🎯 Key points to review

- 

## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

## 📎 Additional Notes

-