### PR TITLE
[FIX/#230,#232] 게시글 작성 중 게시판 목록 관련 문제 해결

### DIFF
--- a/apps/web/src/entities/feed/api/get.ts
+++ b/apps/web/src/entities/feed/api/get.ts
@@ -1,10 +1,20 @@
 import { API } from '@/shared/api';
 
-import { type GetAvailableBoardListResponseDto } from '../model';
+import {
+  type GetWritableBoardListResponseDto,
+  type GetAvailableBoardListResponseDto,
+} from '../model';
 
 export const getAvailableBoards = async () => {
   const response = await API.get<GetAvailableBoardListResponseDto>(
     '/api/v2/boards/available',
+  );
+  return response;
+};
+
+export const getWritableBoards = async () => {
+  const response = await API.get<GetWritableBoardListResponseDto>(
+    '/api/v2/boards/writable',
   );
   return response;
 };

--- a/apps/web/src/entities/feed/api/index.ts
+++ b/apps/web/src/entities/feed/api/index.ts
@@ -1,1 +1,1 @@
-export { getAvailableBoards } from './get';
+export { getAvailableBoards, getWritableBoards } from './get';

--- a/apps/web/src/entities/feed/config/query/boardQueryKeys.ts
+++ b/apps/web/src/entities/feed/config/query/boardQueryKeys.ts
@@ -1,4 +1,5 @@
 export const boardQueryKeys = {
   all: ['boards'] as const,
   available: () => [...boardQueryKeys.all, 'available'] as const,
+  writable: () => [...boardQueryKeys.all, 'writable'] as const,
 };

--- a/apps/web/src/entities/feed/config/query/boardQueryOptions.ts
+++ b/apps/web/src/entities/feed/config/query/boardQueryOptions.ts
@@ -2,7 +2,7 @@ import { queryOptions } from '@tanstack/react-query';
 
 import { QUERY_STALE_TIME } from '@/shared/constants';
 
-import { getAvailableBoards } from '../../api';
+import { getAvailableBoards, getWritableBoards } from '../../api';
 
 import { boardQueryKeys } from './boardQueryKeys';
 
@@ -11,6 +11,13 @@ export const boardQueryOptions = {
     queryOptions({
       queryKey: boardQueryKeys.available(),
       queryFn: getAvailableBoards,
+      staleTime: QUERY_STALE_TIME.DEFAULT,
+      throwOnError: true,
+    }),
+  writable: () =>
+    queryOptions({
+      queryKey: boardQueryKeys.writable(),
+      queryFn: getWritableBoards,
       staleTime: QUERY_STALE_TIME.DEFAULT,
       throwOnError: true,
     }),

--- a/apps/web/src/entities/feed/index.ts
+++ b/apps/web/src/entities/feed/index.ts
@@ -14,6 +14,7 @@ export {
 } from './config';
 export {
   useGetAvailableBoards,
+  useGetWritableBoards,
   useFeedSearchKeyword,
   useMyFeedView,
   useFeedSearchPendingKeywordContext,

--- a/apps/web/src/entities/feed/model/index.ts
+++ b/apps/web/src/entities/feed/model/index.ts
@@ -1,5 +1,9 @@
-export { useGetAvailableBoards } from './queries';
-export type { Board, GetAvailableBoardListResponseDto } from './types';
+export { useGetAvailableBoards, useGetWritableBoards } from './queries';
+export type {
+  Board,
+  GetAvailableBoardListResponseDto,
+  GetWritableBoardListResponseDto,
+} from './types';
 export {
   useFeedSearchKeyword,
   useMyFeedView,

--- a/apps/web/src/entities/feed/model/queries/index.ts
+++ b/apps/web/src/entities/feed/model/queries/index.ts
@@ -1,1 +1,2 @@
 export * from './useGetAvailableBoards';
+export * from './useGetWritableBoards';

--- a/apps/web/src/entities/feed/model/queries/useGetWritableBoards.ts
+++ b/apps/web/src/entities/feed/model/queries/useGetWritableBoards.ts
@@ -1,0 +1,9 @@
+'use client';
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { boardQueryOptions } from '../../config';
+
+export const useGetWritableBoards = () => {
+  return useSuspenseQuery(boardQueryOptions.writable());
+};

--- a/apps/web/src/entities/feed/model/types/dto/getWritableBoardListDto.ts
+++ b/apps/web/src/entities/feed/model/types/dto/getWritableBoardListDto.ts
@@ -1,0 +1,5 @@
+import { type Board } from '../boards';
+
+export interface GetWritableBoardListResponseDto {
+  boards: Board[];
+}

--- a/apps/web/src/entities/feed/model/types/dto/index.ts
+++ b/apps/web/src/entities/feed/model/types/dto/index.ts
@@ -1,1 +1,2 @@
 export type { GetAvailableBoardListResponseDto } from './getAvailableBoardListDto';
+export type { GetWritableBoardListResponseDto } from './getWritableBoardListDto';

--- a/apps/web/src/entities/feed/model/types/index.ts
+++ b/apps/web/src/entities/feed/model/types/index.ts
@@ -1,2 +1,5 @@
 export type { Board } from './boards';
-export type { GetAvailableBoardListResponseDto } from './dto';
+export type {
+  GetAvailableBoardListResponseDto,
+  GetWritableBoardListResponseDto,
+} from './dto';

--- a/apps/web/src/features/post/ui/PostWriteBody.tsx
+++ b/apps/web/src/features/post/ui/PostWriteBody.tsx
@@ -17,6 +17,7 @@ interface PostWriteBodyProps {
   vote: VoteWriteValue | null;
   setVote: (vote: VoteWriteValue | null) => void;
   isEdit?: boolean;
+  hideBoardSelector?: boolean;
 }
 
 export const PostWriteBody = ({
@@ -27,6 +28,7 @@ export const PostWriteBody = ({
   vote,
   setVote,
   isEdit,
+  hideBoardSelector,
 }: PostWriteBodyProps) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -60,19 +62,23 @@ export const PostWriteBody = ({
         msOverflowStyle: 'auto',
       }}
     >
-      <Chip
-        asChild
-        color="lightgray"
-        className={mergeStyles(
-          'transition-color mx-4 w-fit shrink-0 md:mt-4',
-          !isEdit ? 'cursor-pointer hover:bg-gray-200 active:bg-gray-200' : '',
-        )}
-      >
-        <button onClick={onSelectorClick} disabled={isEdit}>
-          {selectedBoard ? selectedBoard.name : '주제를 선택해주세요'}
-          <ArrowDown size={14} color="gray-500" />
-        </button>
-      </Chip>
+      {!hideBoardSelector && (
+        <Chip
+          asChild
+          color="lightgray"
+          className={mergeStyles(
+            'transition-color mx-4 w-fit shrink-0 md:mt-4',
+            !isEdit
+              ? 'cursor-pointer hover:bg-gray-200 active:bg-gray-200'
+              : '',
+          )}
+        >
+          <button onClick={onSelectorClick} disabled={isEdit}>
+            {selectedBoard ? selectedBoard.name : '주제를 선택해주세요'}
+            <ArrowDown size={14} color="gray-500" />
+          </button>
+        </Chip>
+      )}
 
       <VStack gap="lg" className="mx-5 my-4">
         <TextArea className="p-0 ring-0 focus-within:ring-0">

--- a/apps/web/src/features/post/ui/PostWriteForm.tsx
+++ b/apps/web/src/features/post/ui/PostWriteForm.tsx
@@ -6,7 +6,7 @@ import { FormProvider } from 'react-hook-form';
 
 import { Box, Dialog, VStack } from '@causw/cds';
 
-import { type Board, useGetAvailableBoards } from '@/entities/feed';
+import { type Board, useGetWritableBoards } from '@/entities/feed';
 import {
   type PostCreateFormValues,
   type PostUpdateFormValues,
@@ -38,7 +38,7 @@ export const PostWriteForm = ({
   initialImages = [],
 }: PostWriteFormProps) => {
   const isEdit = !!postId;
-  const { data: boardData } = useGetAvailableBoards();
+  const { data: boardData } = useGetWritableBoards();
 
   const form = usePostCreateForm(initialData);
   const { mutate: createPost } = useCreatePostMutation();

--- a/apps/web/src/features/post/ui/PostWriteForm.tsx
+++ b/apps/web/src/features/post/ui/PostWriteForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { FormProvider } from 'react-hook-form';
 
@@ -39,6 +39,7 @@ export const PostWriteForm = ({
 }: PostWriteFormProps) => {
   const isEdit = !!postId;
   const { data: boardData } = useGetWritableBoards();
+  const boards = useMemo(() => boardData?.boards ?? [], [boardData?.boards]);
 
   const form = usePostCreateForm(initialData);
   const { mutate: createPost } = useCreatePostMutation();
@@ -59,8 +60,7 @@ export const PostWriteForm = ({
   const imageUploadRef = useRef<ImageUploadFieldRef>(null);
   const [selectorOpen, setSelectorOpen] = useState(false);
 
-  const selectedBoard =
-    boardData?.boards.find((b) => b.id === currentBoardId) ?? null;
+  const selectedBoard = boards.find((b) => b.id === currentBoardId) ?? null;
 
   const onSubmit = async (data: PostCreateFormValues) => {
     const imageData = data.images as {
@@ -108,6 +108,12 @@ export const PostWriteForm = ({
     }
   };
 
+  useEffect(() => {
+    if (boards.length === 1 && !currentBoardId) {
+      setValue('boardId', boards[0].id, { shouldValidate: true });
+    }
+  }, [boards, currentBoardId, setValue]);
+
   return (
     <FormProvider {...form}>
       <VStack
@@ -133,6 +139,7 @@ export const PostWriteForm = ({
             setValue('vote', val, { shouldValidate: true, shouldDirty: true })
           }
           isEdit={isEdit}
+          hideBoardSelector={boards.length === 1}
         />
 
         <Box className="m-5 mb-0">


### PR DESCRIPTION
# 🚀 Pull Request

## Issue

- Closes #230 
- Closes #232 


## ✨ Summary

`/boards/writable` api를 추가하여 게시글 작성 페이지에서 유저가 작성 가능한 게시판 목록만 보이도록 수정했고,
유저가 작성 가능한 게시판이 1개일 경우 게시판을 자동 선택하고, '주제를 선택하세요' ui가 보이지 않도록 수정했습니다.

## 📚 Details of Changes

- 게시글 작성 중 '주제를 선택하세요' 부분에서 조회하는 게시판 목록 api를 writable로 변경
- 유저가 작성 가능한 게시판이 1개일 경우(일반 유저) 게시판 자동 선택 + 게시판 선택 ui 안보이게 수정 (`PostWriteForm`, `PostWriteBody`)

## 🎯 Key points to review

- 

## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

- 유저가 작성 가능한 게시판 목록만 보이게

<img width="600" alt="image" src="https://github.com/user-attachments/assets/cbdb3794-fa04-4bd2-8b55-0470c9c16fc7" />

- 작성 가능한 게시판이 1개인 경우

<img width="600" alt="image" src="https://github.com/user-attachments/assets/67b6ad9c-cffc-4e0a-9d08-c60268f75592" />

## 📎 Additional Notes

-