### PR TITLE
[FIX/#235] 경조사 신청 입력 검증 오류 메시지 미노출 및 과거 날짜 제한 미작동 bug 버그 수정

### DIFF
--- a/apps/web/src/entities/ceremony/model/form/schema.ts
+++ b/apps/web/src/entities/ceremony/model/form/schema.ts
@@ -1,9 +1,20 @@
 import { z } from 'zod';
 
-import { isValidTimeFormat, isEndDateTimeBeforeStart } from '@/shared/lib';
-import { phoneNumberSchema } from '@/shared/model/form';
+import {
+  isValidTimeFormat,
+  isEndDateTimeBeforeStart,
+  isDateBeforeToday,
+} from '@/shared/lib';
 
 import { CUSTOM_VALUE } from '../../config';
+
+const CEREMONY_PHONE_MESSAGE =
+  '문의 연락처는 010-1234-5678 형식으로 입력해주세요.';
+const ceremonyPhoneSchema = z
+  .string()
+  .min(11, CEREMONY_PHONE_MESSAGE)
+  .max(13, CEREMONY_PHONE_MESSAGE)
+  .regex(/^01(?:0|1|[6-9])-(\d{3}|\d{4})-\d{4}$/, CEREMONY_PHONE_MESSAGE);
 
 export const ceremonyFormSchema = z
   .object({
@@ -32,7 +43,7 @@ export const ceremonyFormSchema = z
     postalCode: z.string(),
     address: z.string(),
     detailAddress: z.string(),
-    phone: z.union([z.literal(''), phoneNumberSchema]),
+    phone: z.union([z.literal(''), ceremonyPhoneSchema]),
     relatedLink: z.string(),
   })
   .superRefine((data, ctx) => {
@@ -67,6 +78,12 @@ export const ceremonyFormSchema = z
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: '시작일을 선택해주세요.',
+        path: ['startDate'],
+      });
+    } else if (isDateBeforeToday(data.startDate)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: '시작일은 오늘 이전일 수 없습니다.',
         path: ['startDate'],
       });
     }

--- a/apps/web/src/features/ceremony/model/useAdmissionYear.ts
+++ b/apps/web/src/features/ceremony/model/useAdmissionYear.ts
@@ -18,7 +18,10 @@ export const useAdmissionYear = (
     if (!/^\d{4}$/.test(trimmed)) return;
     const current = getValues('admissionYears');
     if (!current.includes(trimmed)) {
-      setValue('admissionYears', [...current, trimmed]);
+      setValue('admissionYears', [...current, trimmed], {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
     }
     setAdmissionYearInput('');
     setShowAdmissionYearModal(false);
@@ -29,6 +32,7 @@ export const useAdmissionYear = (
     setValue(
       'admissionYears',
       current.filter((y) => y !== year),
+      { shouldDirty: true, shouldValidate: true },
     );
   };
 

--- a/apps/web/src/features/ceremony/model/useCeremonyForm.ts
+++ b/apps/web/src/features/ceremony/model/useCeremonyForm.ts
@@ -20,6 +20,7 @@ export const useCeremonyForm = () => {
   });
 
   const { control, setValue, reset } = methods;
+  const validateOptions = { shouldDirty: true, shouldValidate: true };
 
   // --- 닫기 확인 ---
   const [showCloseConfirm, setShowCloseConfirm] = useState(false);
@@ -30,20 +31,20 @@ export const useCeremonyForm = () => {
 
   // --- Handlers ---
   const handleTypeChange = (type: CeremonyType) => {
-    setValue('ceremonyType', type);
-    setValue('category', '');
-    setValue('customCategory', '');
+    setValue('ceremonyType', type, validateOptions);
+    setValue('category', '', validateOptions);
+    setValue('customCategory', '', validateOptions);
   };
 
   const handleRelationshipChange = (
     value: CeremonyFormData['relationship'],
   ) => {
-    setValue('relationship', value);
-    setValue('familyRelation', '');
-    setValue('customFamilyRelation', '');
-    setValue('alumniName', '');
-    setValue('alumniAdmissionYear', '');
-    setValue('alumniRelation', '');
+    setValue('relationship', value, validateOptions);
+    setValue('familyRelation', '', validateOptions);
+    setValue('customFamilyRelation', '', validateOptions);
+    setValue('alumniName', '', validateOptions);
+    setValue('alumniAdmissionYear', '', validateOptions);
+    setValue('alumniRelation', '', validateOptions);
   };
 
   // --- 폼 초기화 ---

--- a/apps/web/src/features/ceremony/model/useImageUpload.ts
+++ b/apps/web/src/features/ceremony/model/useImageUpload.ts
@@ -10,7 +10,22 @@ export const useImageUpload = () => {
   const [photoFiles, setPhotoFiles] = useState<File[]>([]);
 
   const handleSetPhotoFiles = useCallback((_name: string, value: unknown) => {
-    setPhotoFiles(value as File[]);
+    if (Array.isArray(value)) {
+      setPhotoFiles(value);
+      return;
+    }
+
+    if (
+      value &&
+      typeof value === 'object' &&
+      'newImageFiles' in value &&
+      Array.isArray(value.newImageFiles)
+    ) {
+      setPhotoFiles(value.newImageFiles);
+      return;
+    }
+
+    setPhotoFiles([]);
   }, []);
 
   const resetImageUpload = () => {

--- a/apps/web/src/features/ceremony/ui/AdmissionYearSection.tsx
+++ b/apps/web/src/features/ceremony/ui/AdmissionYearSection.tsx
@@ -18,7 +18,12 @@ import { FormSection } from '@/shared/ui/form-section';
 import { useAdmissionYear } from '../model/useAdmissionYear';
 
 export const AdmissionYearSection = () => {
-  const { control, getValues, setValue } = useFormContext<CeremonyFormData>();
+  const {
+    control,
+    getValues,
+    setValue,
+    formState: { errors },
+  } = useFormContext<CeremonyFormData>();
   const {
     showAdmissionYearModal,
     setShowAdmissionYearModal,
@@ -67,13 +72,26 @@ export const AdmissionYearSection = () => {
             control={control}
             name="notifyAll"
             render={({ field }) => (
-              <Checkbox checked={field.value} onCheckedChange={field.onChange}>
+              <Checkbox
+                checked={field.value}
+                onCheckedChange={(checked) => {
+                  field.onChange(!!checked);
+                }}
+              >
                 <Checkbox.Indicator />
                 <Checkbox.Label>모든 학번에게 알림 전송</Checkbox.Label>
               </Checkbox>
             )}
           />
         </div>
+        <Field
+          className="flex flex-col gap-2"
+          error={!!errors.admissionYears?.message}
+        >
+          <Field.ErrorDescription>
+            {errors.admissionYears?.message}
+          </Field.ErrorDescription>
+        </Field>
       </FormSection>
 
       <Modal

--- a/apps/web/src/features/ceremony/ui/CategorySection.tsx
+++ b/apps/web/src/features/ceremony/ui/CategorySection.tsx
@@ -9,7 +9,11 @@ import { RHFTabSelect } from '@/shared/ui';
 import { CATEGORY_MAP, CUSTOM_VALUE } from '../config';
 
 export const CategorySection = () => {
-  const { register, watch } = useFormContext<CeremonyFormData>();
+  const {
+    register,
+    watch,
+    formState: { errors },
+  } = useFormContext<CeremonyFormData>();
   const ceremonyType = watch('ceremonyType');
   const category = watch('category');
 
@@ -27,12 +31,18 @@ export const CategorySection = () => {
       <RHFTabSelect name="category" label="상세 분류" options={options} />
 
       {isCustom && (
-        <Field>
+        <Field
+          className="flex flex-col gap-2"
+          error={!!errors.customCategory?.message}
+        >
           <TextInput
             {...register('customCategory')}
             placeholder={`${ceremonyType}를 입력해주세요.`}
             className="rounded-xl bg-white"
           />
+          <Field.ErrorDescription>
+            {errors.customCategory?.message}
+          </Field.ErrorDescription>
         </Field>
       )}
     </>

--- a/apps/web/src/features/ceremony/ui/CeremonyCreateDialog.tsx
+++ b/apps/web/src/features/ceremony/ui/CeremonyCreateDialog.tsx
@@ -58,8 +58,7 @@ export const CeremonyCreateDialog = ({
     onOpenChange(nextOpen);
   };
 
-  const handleSubmit = () => {
-    const formValues = form.methods.getValues();
+  const handleSubmit = form.methods.handleSubmit((formValues) => {
     const dto = toCreateCeremonyDto(formValues);
 
     mutation.mutate(
@@ -72,7 +71,7 @@ export const CeremonyCreateDialog = ({
         },
       },
     );
-  };
+  });
 
   const canSubmit = form.isValid && !mutation.isPending;
 

--- a/apps/web/src/features/ceremony/ui/ContactSection.tsx
+++ b/apps/web/src/features/ceremony/ui/ContactSection.tsx
@@ -7,16 +7,20 @@ import type { CeremonyFormData } from '@/entities/ceremony';
 import { FormSection } from '@/shared/ui/form-section';
 
 export const ContactSection = () => {
-  const { register } = useFormContext<CeremonyFormData>();
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext<CeremonyFormData>();
 
   return (
     <FormSection title="문의" optional>
-      <Field>
+      <Field className="flex flex-col gap-2" error={!!errors.phone?.message}>
         <TextInput
           {...register('phone')}
           placeholder="연락 가능한 전화번호를 입력해주세요."
           className="rounded-xl bg-white"
         />
+        <Field.ErrorDescription>{errors.phone?.message}</Field.ErrorDescription>
       </Field>
     </FormSection>
   );

--- a/apps/web/src/features/ceremony/ui/DateTimeSection.tsx
+++ b/apps/web/src/features/ceremony/ui/DateTimeSection.tsx
@@ -14,24 +14,25 @@ const END_DATE_ERROR_MESSAGE = '종료일은 시작일 이후여야 합니다.';
 
 export const DateTimeSection = () => {
   const { control, setValue, getValues } = useFormContext<CeremonyFormData>();
+  const validateOptions = { shouldDirty: true, shouldValidate: true };
   const [hasEndDate, hasTime] = useWatch({
     control,
     name: ['hasEndDate', 'hasTime'],
   });
 
   const handleEndDateToggle = (checked: boolean) => {
-    setValue('hasEndDate', checked);
-    if (!checked) setValue('endDate', undefined);
+    setValue('hasEndDate', checked, validateOptions);
+    if (!checked) setValue('endDate', undefined, validateOptions);
   };
 
   const handleTimeToggle = (checked: boolean) => {
-    setValue('hasTime', checked);
+    setValue('hasTime', checked, validateOptions);
     if (checked) {
-      setValue('startTime', getValues('startTime') ?? '');
-      setValue('endTime', getValues('endTime') ?? '');
+      setValue('startTime', getValues('startTime') ?? '', validateOptions);
+      setValue('endTime', getValues('endTime') ?? '', validateOptions);
     } else {
-      setValue('startTime', '');
-      setValue('endTime', '');
+      setValue('startTime', '', validateOptions);
+      setValue('endTime', '', validateOptions);
     }
   };
 
@@ -74,13 +75,13 @@ export const DateTimeSection = () => {
   const handleTimeChange =
     (field: 'startTime' | 'endTime') =>
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      setValue(field, e.target.value);
+      setValue(field, e.target.value, validateOptions);
     };
 
   const handleTimeBlur = (field: 'startTime' | 'endTime') => () => {
     const rawValue = getValues(field);
     if (rawValue) {
-      setValue(field, formatTime(rawValue));
+      setValue(field, formatTime(rawValue), validateOptions);
     }
     checkEndBeforeStart();
   };
@@ -94,17 +95,25 @@ export const DateTimeSection = () => {
             <Controller
               control={control}
               name="startDate"
-              render={({ field }) => (
-                <DatePicker
-                  value={field.value}
-                  onValueChange={(date) =>
-                    handleStartDateChange(date, field.onChange)
-                  }
-                  placeholder="연도-월-일"
-                  dateFormat="yyyy-MM-dd"
-                  className="w-full rounded-xl bg-white"
-                  contentClassName="z-modal"
-                />
+              render={({ field, fieldState }) => (
+                <Field
+                  className="flex flex-col gap-2"
+                  error={!!fieldState.error?.message}
+                >
+                  <DatePicker
+                    value={field.value}
+                    onValueChange={(date) =>
+                      handleStartDateChange(date, field.onChange)
+                    }
+                    placeholder="연도-월-일"
+                    dateFormat="yyyy-MM-dd"
+                    className="w-full rounded-xl bg-white"
+                    contentClassName="z-modal"
+                  />
+                  <Field.ErrorDescription>
+                    {fieldState.error?.message}
+                  </Field.ErrorDescription>
+                </Field>
               )}
             />
           </div>
@@ -116,8 +125,11 @@ export const DateTimeSection = () => {
                   <Controller
                     control={control}
                     name="startTime"
-                    render={({ field }) => (
-                      <Field>
+                    render={({ field, fieldState }) => (
+                      <Field
+                        className="flex flex-col gap-2"
+                        error={!!fieldState.error?.message}
+                      >
                         <TextInput
                           value={field.value}
                           onChange={handleTimeChange('startTime')}
@@ -127,6 +139,9 @@ export const DateTimeSection = () => {
                           inputMode="numeric"
                           className="rounded-xl bg-white"
                         />
+                        <Field.ErrorDescription>
+                          {fieldState.error?.message}
+                        </Field.ErrorDescription>
                       </Field>
                     )}
                   />
@@ -134,17 +149,25 @@ export const DateTimeSection = () => {
                   <Controller
                     control={control}
                     name="endDate"
-                    render={({ field }) => (
-                      <DatePicker
-                        value={field.value}
-                        onValueChange={(date) =>
-                          handleEndDateChange(date, field.onChange)
-                        }
-                        placeholder="연도-월-일"
-                        dateFormat="yyyy-MM-dd"
-                        className="w-full rounded-xl bg-white"
-                        contentClassName="z-modal"
-                      />
+                    render={({ field, fieldState }) => (
+                      <Field
+                        className="flex flex-col gap-2"
+                        error={!!fieldState.error?.message}
+                      >
+                        <DatePicker
+                          value={field.value}
+                          onValueChange={(date) =>
+                            handleEndDateChange(date, field.onChange)
+                          }
+                          placeholder="연도-월-일"
+                          dateFormat="yyyy-MM-dd"
+                          className="w-full rounded-xl bg-white"
+                          contentClassName="z-modal"
+                        />
+                        <Field.ErrorDescription>
+                          {fieldState.error?.message}
+                        </Field.ErrorDescription>
+                      </Field>
                     )}
                   />
                 )}
@@ -160,17 +183,25 @@ export const DateTimeSection = () => {
               <Controller
                 control={control}
                 name="endDate"
-                render={({ field }) => (
-                  <DatePicker
-                    value={field.value}
-                    onValueChange={(date) =>
-                      handleEndDateChange(date, field.onChange)
-                    }
-                    placeholder="연도-월-일"
-                    dateFormat="yyyy-MM-dd"
-                    className="w-full rounded-xl bg-white"
-                    contentClassName="z-modal"
-                  />
+                render={({ field, fieldState }) => (
+                  <Field
+                    className="flex flex-col gap-2"
+                    error={!!fieldState.error?.message}
+                  >
+                    <DatePicker
+                      value={field.value}
+                      onValueChange={(date) =>
+                        handleEndDateChange(date, field.onChange)
+                      }
+                      placeholder="연도-월-일"
+                      dateFormat="yyyy-MM-dd"
+                      className="w-full rounded-xl bg-white"
+                      contentClassName="z-modal"
+                    />
+                    <Field.ErrorDescription>
+                      {fieldState.error?.message}
+                    </Field.ErrorDescription>
+                  </Field>
                 )}
               />
             </div>
@@ -178,8 +209,11 @@ export const DateTimeSection = () => {
             <Controller
               control={control}
               name="endTime"
-              render={({ field }) => (
-                <Field className="min-w-0 flex-1">
+              render={({ field, fieldState }) => (
+                <Field
+                  className="flex min-w-0 flex-1 flex-col gap-2"
+                  error={!!fieldState.error?.message}
+                >
                   <TextInput
                     value={field.value}
                     onChange={handleTimeChange('endTime')}
@@ -189,6 +223,9 @@ export const DateTimeSection = () => {
                     inputMode="numeric"
                     className="rounded-xl bg-white"
                   />
+                  <Field.ErrorDescription>
+                    {fieldState.error?.message}
+                  </Field.ErrorDescription>
                 </Field>
               )}
             />

--- a/apps/web/src/features/ceremony/ui/RelationshipSection.tsx
+++ b/apps/web/src/features/ceremony/ui/RelationshipSection.tsx
@@ -21,7 +21,11 @@ interface RelationshipSectionProps {
 export const RelationshipSection = ({
   onRelationshipChange,
 }: RelationshipSectionProps) => {
-  const { control, register } = useFormContext<CeremonyFormData>();
+  const {
+    control,
+    register,
+    formState: { errors },
+  } = useFormContext<CeremonyFormData>();
   const relationship = useWatch({ control, name: 'relationship' });
   const familyRelation = useWatch({ control, name: 'familyRelation' });
 
@@ -59,12 +63,18 @@ export const RelationshipSection = ({
             />
           </div>
           {familyRelation === CUSTOM_VALUE && (
-            <Field>
+            <Field
+              className="flex flex-col gap-2"
+              error={!!errors.customFamilyRelation?.message}
+            >
               <TextInput
                 {...register('customFamilyRelation')}
                 placeholder="상세 관계를 입력해주세요."
                 className="rounded-xl bg-white"
               />
+              <Field.ErrorDescription>
+                {errors.customFamilyRelation?.message}
+              </Field.ErrorDescription>
             </Field>
           )}
         </>
@@ -73,22 +83,34 @@ export const RelationshipSection = ({
       {relationship === '동문소식 대신 전달' && (
         <>
           <FormSection title="대상 성함">
-            <Field>
+            <Field
+              className="flex flex-col gap-2"
+              error={!!errors.alumniName?.message}
+            >
               <TextInput
                 {...register('alumniName')}
                 placeholder="대상 성함을 입력해주세요."
                 className="rounded-xl bg-white"
               />
+              <Field.ErrorDescription>
+                {errors.alumniName?.message}
+              </Field.ErrorDescription>
             </Field>
           </FormSection>
 
           <FormSection title="동문 학번 (입학년도)">
-            <Field>
+            <Field
+              className="flex flex-col gap-2"
+              error={!!errors.alumniAdmissionYear?.message}
+            >
               <TextInput
                 {...register('alumniAdmissionYear')}
                 placeholder="동문 학번을 입력해주세요."
                 className="rounded-xl bg-white"
               />
+              <Field.ErrorDescription>
+                {errors.alumniAdmissionYear?.message}
+              </Field.ErrorDescription>
             </Field>
           </FormSection>
           <div className="md:w-1/2">

--- a/apps/web/src/shared/lib/timeValidation.ts
+++ b/apps/web/src/shared/lib/timeValidation.ts
@@ -18,6 +18,9 @@ export const isValidTimeFormat = (value: string): boolean => {
 
 const toDateOnly = (date: Date): number => new Date(date).setHours(0, 0, 0, 0);
 
+export const isDateBeforeToday = (date: Date): boolean =>
+  toDateOnly(date) < toDateOnly(new Date());
+
 /**
  * 종료일시가 시작 일시보다 이전인지 판단
  * - 날짜가 다르면 날짜만으로 비교

--- a/apps/web/src/shared/model/form/schema.ts
+++ b/apps/web/src/shared/model/form/schema.ts
@@ -20,11 +20,11 @@ export const nameSchema = z.string().min(1, '이름을 입력해주세요.');
 
 export const phoneNumberSchema = z
   .string()
-  .min(11, '올바른 전화번호 형식이 아닙니다.')
-  .max(13, '올바른 전화번호 형식이 아닙니다.')
+  .min(11, '연락처는 010-1234-5678 형식으로 입력해주세요.')
+  .max(13, '연락처는 010-1234-5678 형식으로 입력해주세요.')
   .regex(
     /^01(?:0|1|[6-9])-(\d{3}|\d{4})-\d{4}$/,
-    '올바른 연락처 형식이 아닙니다.',
+    '연락처는 010-1234-5678 형식으로 입력해주세요.',
   );
 
 export const nicknameSchema = z


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #235

## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 경조사 신청 폼의 필수값/날짜/문의 연락처 검증 오류 메시지를 사용자에게 노출하도록 개선했습니다.

## 📚 Details of Changes

- 경조사 신청 필수값 누락 시 각 필드에 RHF 에러 메시지가 표시되도록 수정
- 시작일이 오늘 이전인 경우 신청할 수 없도록 프론트 검증 추가
- 문의 연락처 형식 오류 시 필드 하단에 안내 문구 표시
- 제출 시 `react-hook-form`의 `handleSubmit`을 거치도록 보강
- 경조사 이미지 업로드 값이 객체 형태로 전달될 때 `newImageFiles`만 추출하도록 수정

## 🎯 Key points to review

- 필수값 누락/과거 시작일/연락처 형식 오류 메시지가 적절한 위치에 표시되는지
- 날짜 검증 기준이 “오늘 이전 불가” 정책과 맞는지
- 문의 연락처 에러 문구가 UX 관점에서 자연스러운지
- 이미지 첨부 여부와 관계없이 경조사 신청 제출이 정상 동작하는지

## 🧪 Test & Verification
<img width="307" alt="image" src="https://github.com/user-attachments/assets/6a77b530-5a13-407c-9ab7-2594e9364f03" /><img width="307" alt="image" src="https://github.com/user-attachments/assets/bca52b1e-ae6a-4eee-a3ad-5ca0de43466b" />

- 이미지 첨부 없이 경조사 신청 시 `imageFiles.forEach is not a function` 오류가 발생하지 않도록 수정
<img width="308" alt="image" src="https://github.com/user-attachments/assets/9e7f2630-6117-4111-916d-7eeaaa2bde97" />

https://github.com/user-attachments/assets/028a73cd-51ad-456a-a759-3c7d64e8880e


## 📎 Additional Notes
- 백엔드 API 직접 호출 시 과거 `startDate` 경조사 생성이 가능한 것을 확인하여, 백엔드에도 동일한 검증 추가가 필요합니다.
- `ImageUploadField`가 기본적으로 `{ existingImages, newImageFiles }` 형태를 넘기므로, 경조사 신청 API에는 `newImageFiles`만 전달되도록 정규화했습니다.