### PR TITLE
[FIX/#236] 동문수첩 SNS 링크 모달 UI 깨짐 bug 버그 수정

### DIFF
--- a/apps/web/src/entities/alumni-contacts/index.ts
+++ b/apps/web/src/entities/alumni-contacts/index.ts
@@ -50,5 +50,6 @@ export {
   checkAlumniContactsFilterSearchParamValidation,
   formatAlumniContactsPeriod,
   getAlumniContactSnsType,
+  getValidAlumniContactsSocialLinkUrl,
 } from './lib';
 export { alumniContactsHandler } from './mock';

--- a/apps/web/src/entities/alumni-contacts/lib/getValidAlumniContactsSocialLinkUrl.ts
+++ b/apps/web/src/entities/alumni-contacts/lib/getValidAlumniContactsSocialLinkUrl.ts
@@ -1,0 +1,13 @@
+export const getValidAlumniContactsSocialLinkUrl = (socialLink: string) => {
+  try {
+    const url = new URL(socialLink.trim());
+
+    if (url.protocol !== 'https:') {
+      return null;
+    }
+
+    return url;
+  } catch {
+    return null;
+  }
+};

--- a/apps/web/src/entities/alumni-contacts/lib/index.ts
+++ b/apps/web/src/entities/alumni-contacts/lib/index.ts
@@ -2,3 +2,4 @@ export { AlumniContactsFilterSearchParam } from './alumniContactsFilterSearchPar
 export { checkAlumniContactsFilterSearchParamValidation } from './checkAlumniContactsFilterSearchParamValidation';
 export { formatAlumniContactsPeriod } from './formatAlumniContactsPeriod';
 export { getAlumniContactSnsType } from './getAlumniContactSnsType';
+export { getValidAlumniContactsSocialLinkUrl } from './getValidAlumniContactsSocialLinkUrl';

--- a/apps/web/src/widgets/alumni-contacts/model/hooks/useAlumniContactsSnsAddDialog.ts
+++ b/apps/web/src/widgets/alumni-contacts/model/hooks/useAlumniContactsSnsAddDialog.ts
@@ -15,6 +15,7 @@ import { useFormContext } from 'react-hook-form';
 import {
   ALUMNI_CONTACTS_EDIT_FORM_FIELD,
   type AlumniContactsEditForm,
+  getValidAlumniContactsSocialLinkUrl,
   useWatchAlumniContactsEditFormField,
 } from '@/entities/alumni-contacts';
 import { ALUMNI_CONTACTS_EDIT_FORM_MAX_LIMIT } from '@/entities/alumni-contacts/config';
@@ -38,13 +39,11 @@ export const useAlumniContactsSnsAddDialog = () => {
     );
   }, [socialLinks]);
 
-  const SNS_URL_PREFIX = 'https://';
-
   const isValid = useMemo(() => {
     if (newSocialLink.trim() === '') {
       return true;
     }
-    return newSocialLink.startsWith(SNS_URL_PREFIX);
+    return getValidAlumniContactsSocialLinkUrl(newSocialLink) !== null;
   }, [newSocialLink]);
 
   useEffect(() => {
@@ -95,7 +94,7 @@ export const useAlumniContactsSnsAddDialog = () => {
 
     // 중복 SNS 링크 덮어쓰기
     const currentSocialLinkSet = new Set(socialLinks);
-    currentSocialLinkSet.add(newSocialLink);
+    currentSocialLinkSet.add(newSocialLink.trim());
 
     setValue(
       ALUMNI_CONTACTS_EDIT_FORM_FIELD.SOCIAL_LINKS,

--- a/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-etc-link-confirm-dialog/AlumniContactsEtcLinkConfirmDialog.tsx
+++ b/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-etc-link-confirm-dialog/AlumniContactsEtcLinkConfirmDialog.tsx
@@ -4,6 +4,7 @@ import {
   ALUMNI_CONTACTS_SNS_TYPE,
   ALUMNI_CONTACTS_SNS_TYPE_LABEL,
   AlumniContactsSnsIcon,
+  getValidAlumniContactsSocialLinkUrl,
 } from '@/entities/alumni-contacts';
 
 interface AlumniContactsEtcLinkConfirmDialogProps {
@@ -14,9 +15,15 @@ export const AlumniContactsEtcLinkConfirmDialog = ({
   socialLink,
 }: AlumniContactsEtcLinkConfirmDialogProps) => {
   const snsType = ALUMNI_CONTACTS_SNS_TYPE.ETC;
+  const socialLinkUrl = getValidAlumniContactsSocialLinkUrl(socialLink);
+  const isValidSocialLink = socialLinkUrl !== null;
 
   const handleOpenEtcLink = () => {
-    window.open(socialLink, '_blank');
+    if (!socialLinkUrl) {
+      return;
+    }
+
+    window.open(socialLinkUrl.href, '_blank', 'noopener,noreferrer');
   };
 
   return (
@@ -35,25 +42,54 @@ export const AlumniContactsEtcLinkConfirmDialog = ({
           </Text>
         </Button>
       </Dialog.Trigger>
-      <Dialog.Content>
+      <Dialog.Content className="max-h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)]! max-w-80! gap-4 overflow-y-auto md:max-w-105!">
         <Dialog.Title>
           <Text typography="subtitle-18-bold" textColor="gray-800">
-            신뢰할 수 없는 링크입니다
+            {isValidSocialLink
+              ? '신뢰할 수 없는 링크입니다'
+              : '올바르지 않은 링크입니다'}
           </Text>
         </Dialog.Title>
-        <Text typography="body-14-regular" textColor="gray-600">
-          <Text typography="body-14-regular" textColor="blue-500">
+        <Dialog.Description className="sr-only">
+          기타 링크 이동 확인
+        </Dialog.Description>
+        <div className="min-w-0">
+          <Text typography="body-14-regular" textColor="gray-600">
+            {isValidSocialLink
+              ? '다음 링크로 이동하시겠습니까?'
+              : '이동할 수 없는 링크입니다.'}
+          </Text>
+          <Text
+            typography="body-14-regular"
+            textColor={isValidSocialLink ? 'blue-500' : 'red-400'}
+            className="mt-2 block max-h-32 min-w-0 overflow-y-auto rounded-md bg-gray-50 px-3 py-2 break-all"
+          >
             {socialLink}
           </Text>
-          로 이동하시겠습니까? 이동하시려면 확인 버튼을 눌러주세요.
-        </Text>
+          {isValidSocialLink && (
+            <Text
+              typography="body-14-regular"
+              textColor="gray-600"
+              className="mt-2 block break-keep"
+            >
+              이동하시려면 확인 버튼을 눌러주세요.
+            </Text>
+          )}
+        </div>
         <Dialog.Footer>
-          <HStack gap="md" className="justify-end">
+          <HStack gap="sm" className="justify-end pt-2">
             <Dialog.Close asChild>
-              <Button color="gray">취소</Button>
+              <Button color="gray" className="h-11 flex-1 rounded-md">
+                취소
+              </Button>
             </Dialog.Close>
             <Dialog.Close asChild>
-              <Button color="red" onClick={handleOpenEtcLink}>
+              <Button
+                color="red"
+                onClick={handleOpenEtcLink}
+                disabled={!isValidSocialLink}
+                className="h-11 flex-1 rounded-md"
+              >
                 확인
               </Button>
             </Dialog.Close>

--- a/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-sns-section/AlumniContactsSnsSection.tsx
+++ b/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-sns-section/AlumniContactsSnsSection.tsx
@@ -4,6 +4,7 @@ import {
   ALUMNI_CONTACTS_SNS_TYPE,
   AlumniContactsSnsLink,
   getAlumniContactSnsType,
+  getValidAlumniContactsSocialLinkUrl,
   type GetAlumniContactsDetailResponseDto,
 } from '@/entities/alumni-contacts';
 
@@ -25,8 +26,10 @@ export const AlumniContactsSnsSection = ({
     <HStack gap="sm" className="overflow-x-auto">
       {socialLinks.map((socialLink) => {
         const snsType = getAlumniContactSnsType(socialLink);
+        const isValidSocialLink =
+          getValidAlumniContactsSocialLinkUrl(socialLink) !== null;
 
-        if (snsType === ALUMNI_CONTACTS_SNS_TYPE.ETC) {
+        if (snsType === ALUMNI_CONTACTS_SNS_TYPE.ETC || !isValidSocialLink) {
           return (
             <AlumniContactsEtcLinkConfirmDialog
               key={socialLink}


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #236

## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 동문수첩 SNS 링크 안내 모달의 모바일 레이아웃 깨짐과 URL 검증 로직을 개선했습니다.

## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- SNS 링크 URL 검증 유틸을 추가해 `https` URL만 유효하게 처리
- SNS 추가 입력 시 단순 prefix 체크 대신 URL 파싱 기반 검증 적용
- 유효하지 않은 SNS 링크는 직접 이동하지 않고 안내 모달로 처리
- 긴 URL이 모바일 모달 밖으로 밀리지 않도록 max-height, overflow, 줄바꿈 스타일 적용

## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- Galaxy S25 등 모바일 화면에서 모달 높이와 URL 줄바꿈이 정상적으로 표시되는지
- 잘못된 URL 입력/노출 시 확인 버튼 비활성화가 의도대로 동작하는지

## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.
<img width="310" alt="image" src="https://github.com/user-attachments/assets/8351a48e-0238-405c-a779-8fec6189fcd9" />

https://github.com/user-attachments/assets/d59aa027-fd80-4edb-b193-4611a39318bf


## 📎 Additional Notes
-