### PR TITLE
[FIX/#250] 동문 상세 정보 탭 모바일 스크롤 이동 보정

### DIFF
--- a/apps/web/src/widgets/alumni-contacts/model/hooks/useAlumniContactsDetailSection.ts
+++ b/apps/web/src/widgets/alumni-contacts/model/hooks/useAlumniContactsDetailSection.ts
@@ -7,7 +7,7 @@ import {
   type AlumniContactsDetailSectionTabType,
 } from '@/entities/alumni-contacts';
 
-import { getScrollContainer } from '@/shared/utils';
+import { getScrollContainer, isMobile } from '@/shared/utils';
 
 export const useAlumniContactsDetailSection = () => {
   const [selectedTab, setSelectedTab] =
@@ -22,6 +22,32 @@ export const useAlumniContactsDetailSection = () => {
 
   const CATEGORY_TAB_SYNC_THRESHOLD = 90; // y좌표가 90px 이하일 때 해당 카테고리가 활성화되도록 함
   const TAB_SYNC_FALLBACK_TIMER = 800; // scrollend 이벤트가 발생하지 않을 경우 탭 동기화를 위한 타이머
+
+  /** 네이티브 앱에서는 scrollIntoView 위치 계산이 달라질 수 있어 직접 중앙 위치를 계산해 스크롤함 */
+  const scrollToCategoryInNativeApp = (target: HTMLSpanElement) => {
+    const scrollContainer = getScrollContainer();
+
+    if (!scrollContainer) {
+      target.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+      });
+      return;
+    }
+
+    /** 기존 웹 동작과 동일하게 타깃 요소가 스크롤 영역의 중앙에 오도록 위치를 계산 */
+    const scrollContainerRect = scrollContainer.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
+    const targetTop =
+      scrollContainer.scrollTop +
+      (targetRect.top - scrollContainerRect.top) -
+      (scrollContainer.clientHeight - targetRect.height) / 2;
+
+    scrollContainer.scrollTo({
+      top: targetTop,
+      behavior: 'smooth',
+    });
+  };
 
   const scheduleTabSyncUnlockOnScrollEnd = (opId: number) => {
     const scrollContainer = getScrollContainer();
@@ -55,12 +81,21 @@ export const useAlumniContactsDetailSection = () => {
     const opId = ++scrollSyncOpIdRef.current;
 
     setSelectedTab(key);
-    categoryRef.current[
-      Object.values(ALUMNI_CONTACTS_DETAIL_SECTION_TAB_TYPE).indexOf(key)
-    ]?.scrollIntoView({
-      behavior: 'smooth',
-      block: 'center',
-    });
+    const targetCategory =
+      categoryRef.current[
+        Object.values(ALUMNI_CONTACTS_DETAIL_SECTION_TAB_TYPE).indexOf(key)
+      ];
+
+    if (targetCategory) {
+      if (isMobile) {
+        scrollToCategoryInNativeApp(targetCategory);
+      } else {
+        targetCategory.scrollIntoView({
+          behavior: 'smooth',
+          block: 'center',
+        });
+      }
+    }
 
     scheduleTabSyncUnlockOnScrollEnd(opId);
   };


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #250


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 앱 환경에서 동문 상세 정보 탭 선택 시 목표 섹션으로 정확히 이동하도록 모바일 스크롤 로직을 보정했습니다.


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- 모바일 환경에서는 `scrollIntoView` 대신 스크롤 컨테이너 기준으로 목표 섹션의 중앙 위치를 직접 계산해 이동하도록 변경했습니다.
- 스크롤 컨테이너를 찾지 못한 경우에는 기존 `scrollIntoView` 동작을 fallback으로 유지했습니다.
- 웹 환경에서는 기존 스크롤 동작을 그대로 유지하고, 모바일 환경에만 별도 분기 로직을 적용했습니다.


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- Galaxy S26 Ultra를 포함한 앱 환경에서 각 상세 정보 탭이 선택한 섹션으로 정확히 이동하는지 확인 부탁드립니다.
- 모바일 전용 분기 추가 이후 웹 환경의 기존 탭 이동 동작에 회귀가 없는지 확인 부탁드립니다.


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.

- 별도 자동 테스트는 실행하지 않았습니다.


## 📎 Additional Notes
- 원인 추정: 앱 환경에서 `scrollIntoView({ block: 'center' })`의 위치 계산이 브라우저 환경과 다르게 적용되어 탭 이동 위치가 한 섹션씩 어긋난 것으로 보입니다.