### PR TITLE
[FEAT/254] 동문수첩 contact 컴포넌트 UI 수정

### DIFF
--- a/apps/web/src/entities/alumni-contacts/model/types/dto/getAlumniContactsDto.ts
+++ b/apps/web/src/entities/alumni-contacts/model/types/dto/getAlumniContactsDto.ts
@@ -11,7 +11,7 @@ interface GetAlumniContactsResponseDto {
   name: string;
   admissionYear: string;
   academicStatus: string;
-  description: string;
+  description: string | null;
 }
 
 export type GetPaginatedAlumniContactsResponseDto = PaginationDto<

--- a/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list-item/AlumniContactsListItem.tsx
+++ b/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list-item/AlumniContactsListItem.tsx
@@ -70,7 +70,7 @@ export const AlumniContactsListItem = ({
                 </Text>
               </HStack>
             </VStack>
-            {item.description && item.description.length > 0 && (
+            {item.description && (
               <Text
                 typography="body-15-regular"
                 textColor="gray-700"

--- a/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list-item/AlumniContactsListItem.tsx
+++ b/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list-item/AlumniContactsListItem.tsx
@@ -73,7 +73,7 @@ export const AlumniContactsListItem = ({
             {item.description && item.description.length > 0 && (
               <Text
                 typography="body-15-regular"
-                text-color="gray-700"
+                textColor="gray-700"
                 className="line-clamp-1"
                 as="p"
               >

--- a/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list-item/AlumniContactsListItem.tsx
+++ b/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list-item/AlumniContactsListItem.tsx
@@ -43,32 +43,43 @@ export const AlumniContactsListItem = ({
       >
         <HStack className="min-w-0 grow gap-5" align="center">
           <Avatar src={profileImageUrl} size={64} className="shrink-0" />
-          <VStack gap="none" className="min-w-0 grow">
-            <Text
-              typography="subtitle-16-bold"
-              textColor="gray-700"
-              className="truncate"
-            >
-              {item.name}
-            </Text>
-            <HStack className="min-w-0 items-center gap-2">
+          <VStack gap="xs" className="min-w-0 grow" justify="center">
+            <VStack className="gap-0.5">
               <Text
-                typography="body-14-regular"
-                textColor="gray-400"
-                className="min-w-0 truncate"
+                typography="subtitle-16-bold"
+                textColor="gray-700"
+                className="truncate"
               >
-                {item.admissionYear}
+                {item.name}
               </Text>
-              <div className="h-2 w-px shrink-0 bg-gray-200" />
+              <HStack className="min-w-0 items-center gap-2">
+                <Text
+                  typography="body-14-regular"
+                  textColor="gray-400"
+                  className="min-w-0 truncate"
+                >
+                  {item.admissionYear}
+                </Text>
+                <div className="h-2 w-px shrink-0 bg-gray-200" />
+                <Text
+                  typography="body-14-regular"
+                  textColor="gray-400"
+                  className="min-w-0 truncate"
+                >
+                  {item.academicStatus}
+                </Text>
+              </HStack>
+            </VStack>
+            {item.description && item.description.length > 0 && (
               <Text
-                typography="body-14-regular"
-                textColor="gray-400"
-                className="min-w-0 truncate"
+                typography="body-15-regular"
+                text-color="gray-700"
+                className="line-clamp-1"
+                as="p"
               >
-                {item.academicStatus}
+                {item.description}
               </Text>
-            </HStack>
-            <p className="line-clamp-1">{item.description}</p>
+            )}
           </VStack>
           <ChevronRight
             size={12}


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #254


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 동문수첩 contact 목록 아이템 UI를 디자인 시스템 기준에 맞게 수정했습니다.


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- 동문수첩 contact 목록 아이템의 콘텐츠 영역을 세로 중앙 정렬로 조정했습니다.
- 이름/학번·학적 정보와 소개글 사이 간격을 디자인 기준에 맞게 재구성했습니다.
- 소개글 텍스트에 `body-15-regular`, `gray-700` 스타일을 적용했습니다.
- 소개글이 없는 응답을 고려해 `description` DTO 타입을 `string | null`로 보정하고, 값이 있을 때만 렌더링하도록 처리했습니다.


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- 동문수첩 목록 아이템의 수직 정렬과 간격이 디자인 시스템 기준과 일치하는지
- `description`이 `null`인 경우에도 목록 아이템 레이아웃이 자연스럽게 유지되는지


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.

- `pnpm --filter @causw/web lint` 실행 완료
- `pnpm build:web` 실행 완료
- lint 결과는 기존 경고 5건만 확인되었고, 이번 변경으로 인한 신규 에러는 없었습니다.


## 📎 Additional Notes
- QA 이슈 기준으로 중앙 정렬, 소개글 색상, 요소 간 간격을 반영했습니다.
