### PR TITLE
[FIX/#256] 동문수첩 목록 필터 드롭다운 UI 수정

### DIFF
--- a/apps/web/src/features/alumni-contacts/ui/alumni-contacts-sort-filter-select/AlumniContactsSortFilterSelect.tsx
+++ b/apps/web/src/features/alumni-contacts/ui/alumni-contacts-sort-filter-select/AlumniContactsSortFilterSelect.tsx
@@ -8,13 +8,11 @@ import { useAlumniContactsSortFilter } from '../../model';
 
 export const AlumniContactsSortFilterSelect = () => {
   const { sortType, handleSelectChange } = useAlumniContactsSortFilter();
+  const selectedSortType =
+    sortType ?? ALUMNI_CONTACTS_SORT_FILTER_OPTION.UPDATED_AT_DESC.value;
+
   return (
-    <Select
-      value={
-        sortType ?? ALUMNI_CONTACTS_SORT_FILTER_OPTION.UPDATED_AT_DESC.value
-      }
-      onValueChange={handleSelectChange}
-    >
+    <Select value={selectedSortType} onValueChange={handleSelectChange}>
       <Select.Trigger className="typo-body-15-medium shrink-0 cursor-pointer px-3 py-1.5 text-gray-700 [&_svg]:size-3.5 [&_svg]:fill-current [&_svg]:text-gray-400">
         <Select.Value
           placeholder={ALUMNI_CONTACTS_SORT_FILTER_OPTION.UPDATED_AT_DESC.label}
@@ -26,7 +24,7 @@ export const AlumniContactsSortFilterSelect = () => {
       </Select.Trigger>
       <Select.Content>
         {Object.values(ALUMNI_CONTACTS_SORT_FILTER_OPTION).map((option) => {
-          const isSelected = option.value === sortType;
+          const isSelected = option.value === selectedSortType;
           return (
             <Select.Item
               key={option.value}

--- a/apps/web/src/features/alumni-contacts/ui/alumni-contacts-sort-filter-select/AlumniContactsSortFilterSelect.tsx
+++ b/apps/web/src/features/alumni-contacts/ui/alumni-contacts-sort-filter-select/AlumniContactsSortFilterSelect.tsx
@@ -25,15 +25,23 @@ export const AlumniContactsSortFilterSelect = () => {
         </Select.Value>
       </Select.Trigger>
       <Select.Content>
-        {Object.values(ALUMNI_CONTACTS_SORT_FILTER_OPTION).map((option) => (
-          <Select.Item
-            key={option.value}
-            value={option.value}
-            className="cursor-pointer"
-          >
-            <Text typography="body-16-regular">{option.label}</Text>
-          </Select.Item>
-        ))}
+        {Object.values(ALUMNI_CONTACTS_SORT_FILTER_OPTION).map((option) => {
+          const isSelected = option.value === sortType;
+          return (
+            <Select.Item
+              key={option.value}
+              value={option.value}
+              className="cursor-pointer"
+            >
+              <Text
+                typography={isSelected ? 'subtitle-16-bold' : 'body-16-regular'}
+                textColor={isSelected ? 'gray-800' : 'gray-500'}
+              >
+                {option.label}
+              </Text>
+            </Select.Item>
+          );
+        })}
       </Select.Content>
     </Select>
   );

--- a/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-filter-group/AlumniContactsFilterGroup.tsx
+++ b/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-filter-group/AlumniContactsFilterGroup.tsx
@@ -26,7 +26,7 @@ export const AlumniContactsFilterGroup = () => {
   } = useAlumniContactsFilterGroup();
 
   return (
-    <HStack className="shrink-0 items-center overflow-x-auto">
+    <HStack className="shrink-0 items-center gap-3 overflow-x-auto">
       <AlumniContactsSortFilterSelect />
       <div className="h-3 w-px shrink-0 bg-gray-300" />
       {filterActive ? (


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #256


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 동문수첩 목록 필터 드롭다운 간격과 선택 옵션 텍스트 스타일을 QA 기준에 맞게 조정했습니다.


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- 동문수첩 필터 그룹에 `gap-3`를 추가해 드롭다운과 필터 영역 간 간격을 `12px`로 일관되게 맞췄습니다.
- 정렬 드롭다운에서 선택된 옵션의 텍스트 굵기와 색상을 별도로 적용했습니다.
- 기본 정렬 상태에서도 선택 옵션 강조가 유지되도록 현재 선택값 계산 로직을 정리했습니다.


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- 동문수첩 필터 그룹의 간격이 QA 기준과 일치하는지
- 정렬 드롭다운의 선택/비선택 옵션 텍스트 스타일이 의도대로 표시되는지
- 기본 정렬 상태와 다른 정렬값 선택 시 UI 일관성이 유지되는지


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.

- `pnpm --filter @causw/web exec eslint src/features/alumni-contacts/ui/alumni-contacts-sort-filter-select/AlumniContactsSortFilterSelect.tsx src/widgets/alumni-contacts/ui/alumni-contacts-filter-group/AlumniContactsFilterGroup.tsx` 실행 완료


## 📎 Additional Notes
- QA 문서: [gap 12px](https://www.notion.so/gap-12px-35c739df55f88001a7ffceda1de38fd4?v=30f95333b19f4a71a84c4ada117768d4&source=copy_link)