### PR TITLE
[FIX/#258] 동문수첩 상세 페이지 탭 텍스트 스타일 수정

### DIFF
--- a/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-detail-section-tabs/AlumniContactsDetailSectionTabs.tsx
+++ b/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-detail-section-tabs/AlumniContactsDetailSectionTabs.tsx
@@ -1,4 +1,4 @@
-import { Button, HStack, mergeStyles } from '@causw/cds';
+import { Button, HStack, mergeStyles, Text } from '@causw/cds';
 
 import {
   ALUMNI_CONTACTS_DETAIL_SECTION_TAB_LABEL,
@@ -17,23 +17,32 @@ export const AlumniContactsDetailSectionTabs = ({
   return (
     <HStack className="sticky top-[57.6px] z-100 gap-5 overflow-x-auto bg-white">
       {Object.entries(ALUMNI_CONTACTS_DETAIL_SECTION_TAB_LABEL).map(
-        ([key, value]) => (
-          <Button
-            key={key}
-            color="white"
-            type="button"
-            onClick={() =>
-              handleClickCategoryTab(key as AlumniContactsDetailSectionTabType)
-            }
-            className={mergeStyles(
-              'px-0',
-              selectedTab === key &&
-                'rounded-none border-b-2 border-gray-700 text-gray-700',
-            )}
-          >
-            {value}
-          </Button>
-        ),
+        ([key, value]) => {
+          const isSelected = selectedTab === key;
+          return (
+            <Button
+              key={key}
+              color="white"
+              type="button"
+              onClick={() =>
+                handleClickCategoryTab(
+                  key as AlumniContactsDetailSectionTabType,
+                )
+              }
+              className={mergeStyles(
+                'px-0',
+                isSelected && 'rounded-none border-b-2 border-gray-700',
+              )}
+            >
+              <Text
+                typography="subtitle-16-bold"
+                textColor={isSelected ? 'gray-700' : 'gray-300'}
+              >
+                {value}
+              </Text>
+            </Button>
+          );
+        },
       )}
     </HStack>
   );


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #258


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 동문수첩 상세 페이지 탭 텍스트 스타일을 QA 기준에 맞게 `16-bold`로 수정했습니다.


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- 탭 라벨을 `Text` 컴포넌트로 감싸고 `subtitle-16-bold` 타이포그래피를 적용했습니다.
- 선택된 탭과 비선택 탭의 텍스트 색상을 각각 `gray-700`, `gray-300`으로 분리했습니다.
- 선택 상태 판별값을 재사용하도록 정리해 탭 스타일 적용 로직을 명확하게 했습니다.


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- 동문수첩 상세 페이지 탭 텍스트가 디자인 기준인 `16-bold`로 표시되는지 확인해주세요.


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.

- 별도 테스트는 수행하지 않았습니다.


## 📎 Additional Notes
-
