### PR TITLE
[FIX/#260] 푸시 알림 안드로이드에서 헤드업 배너로 뜨지 않는 이슈

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ next-env.d.ts
 
 # mcp
 mcp.json
+
+.claude
+.bkit

--- a/apps/web/android/build.gradle
+++ b/apps/web/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.2'
+        classpath 'com.android.tools.build:gradle:8.13.2'
         classpath 'com.google.gms:google-services:4.4.2'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/apps/web/android/gradle/wrapper/gradle-wrapper.properties
+++ b/apps/web/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/apps/web/src/app/_provider/capcitor/ForceUpdateProvider.tsx
+++ b/apps/web/src/app/_provider/capcitor/ForceUpdateProvider.tsx
@@ -1,16 +1,41 @@
 'use client';
 
 import { useEffect } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { App } from '@capacitor/app';
+import { PushNotifications } from '@capacitor/push-notifications';
 import { useQuery } from '@tanstack/react-query';
 
 import { CTAButton, Dialog, Text } from '@causw/cds';
 
 import { COPY, QUERY_STALE_TIME } from '@/shared/constants';
 import { checkForceUpdate, openAppStore } from '@/shared/lib';
+import { isAndroid } from '@/shared/utils';
 
 const FORCE_UPDATE_QUERY_KEY = ['force-update'] as const;
+
+/** AndroidManifest `default_notification_channel_id` 와 동일 */
+const ANDROID_DEFAULT_NOTIFICATION_CHANNEL_ID = 'default_channel_id';
+
+export function PushNotificationChannelProvider({
+  children,
+}: PropsWithChildren) {
+  useEffect(() => {
+    if (!isAndroid) {
+      return;
+    }
+
+    void PushNotifications.createChannel({
+      id: ANDROID_DEFAULT_NOTIFICATION_CHANNEL_ID,
+      name: '알림',
+      importance: 4,
+      vibration: true,
+    });
+  }, []);
+
+  return <>{children}</>;
+}
 
 export function ForceUpdateProvider({
   children,

--- a/apps/web/src/app/_provider/index.ts
+++ b/apps/web/src/app/_provider/index.ts
@@ -1,4 +1,7 @@
 export { AuthRefreshProvider } from './auth-refresh';
 export { GlobalRoutingProvider } from './global-routing';
-export { ForceUpdateProvider } from './capcitor';
+export {
+  ForceUpdateProvider,
+  PushNotificationChannelProvider,
+} from './capcitor';
 export { OnboardingGuard } from './onboarding-guard';

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -11,6 +11,7 @@ import {
   AuthRefreshProvider,
   ForceUpdateProvider,
   GlobalRoutingProvider,
+  PushNotificationChannelProvider,
 } from './_provider';
 
 export const metadata: Metadata = {
@@ -36,9 +37,11 @@ export default function RootLayout({
           <QueryProviderWithDevtools>
             <Toaster />
             <ForceUpdateProvider>
-              <AuthRefreshProvider>
-                <GlobalRoutingProvider>{children}</GlobalRoutingProvider>
-              </AuthRefreshProvider>
+              <PushNotificationChannelProvider>
+                <AuthRefreshProvider>
+                  <GlobalRoutingProvider>{children}</GlobalRoutingProvider>
+                </AuthRefreshProvider>
+              </PushNotificationChannelProvider>
             </ForceUpdateProvider>
           </QueryProviderWithDevtools>
         </MSWComponent>


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Close #260


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 안드로이드에서 푸시 알림이 헤드업 배너로 표시되지 않는 버그를 Android 알림 채널 설정 추가로 수정


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- **`PushNotificationChannelProvider` 컴포넌트 신규 추가** (`apps/web/src/app/_provider/capcitor/ForceUpdateProvider.tsx`)
  - `@capacitor/push-notifications`의 `createChannel`을 통해 앱 초기화 시점에 Android 알림 채널을 `importance: 4` (IMPORTANCE_HIGH)로 생성
  - `AndroidManifest.xml`의 `default_notification_channel_id` 값(`default_channel_id`)과 동일한 채널 ID 사용
  - `isAndroid` 가드로 Android 전용 실행 보장
- **`apps/web/src/app/layout.tsx`에 `PushNotificationChannelProvider` 적용**
  - `ForceUpdateProvider` 내부에 래핑하여 앱 최상단에서 채널을 즉시 등록
- **Gradle 버전 업그레이드**
  - Android Gradle Plugin: `8.7.2` → `8.13.2`
  - Gradle Wrapper: `8.11.1` → `8.13`
- **`.gitignore`에 `.claude`, `.bkit` 추가**


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- `importance: 4` 값이 `AndroidManifest.xml`의 채널 설정과 실제로 일치하는지 확인
- `createChannel`이 중복 호출될 경우 Android가 기존 채널을 덮어쓰지 않고 무시하는 동작 의도적으로 허용한 것인지 확인
- `PushNotificationChannelProvider`를 `ForceUpdateProvider` 내부에 둔 레이어 배치가 적절한지 (`app/` 레이어 공통 Provider 구조 관점)


## 🧪 Test & Verification
- [ ] Android 실기기에서 푸시 알림 수신 시 헤드업 배너 표시 확인
- [ ] 앱 포그라운드/백그라운드 양쪽 상태에서 배너 동작 확인
- [ ] iOS에서 기존 푸시 알림 동작 이상 없음 확인 (`isAndroid` 가드 검증)
- [ ] Storybook UI 확인: N/A (Provider 로직 변경만)

> 테스트 결과나 캡처가 있다면 첨부해주세요.


## 📎 Additional Notes
- 개발기간: 2026-05-19 ~ 2026-05-19
- 근본 원인: Capacitor Push Notifications 플러그인은 채널을 자동 생성하지 않아 `importance`가 시스템 기본값(낮음)으로 설정됨. `createChannel`을 명시 호출해야 헤드업 표시 조건인 IMPORTANCE_HIGH가 적용됨
