### PR TITLE
[FIX/#263] 동문수첩 목록 하단 여백 노출 조건 수정

### DIFF
--- a/apps/web/src/_pages/alumni-contacts/list/AlumniContactsListPage.tsx
+++ b/apps/web/src/_pages/alumni-contacts/list/AlumniContactsListPage.tsx
@@ -28,7 +28,7 @@ export async function AlumniContactsListPage({
   await checkAlumniContactsFilterSearchParamValidation(searchParams);
 
   return (
-    <div className="relative flex size-full justify-center p-4 md:px-8 md:py-6">
+    <div className="relative flex size-full justify-center p-4 pb-0 md:px-8 md:pt-6">
       <div className="flex w-full flex-col xl:w-225">
         <VStack className="min-h-0 flex-1 gap-3">
           <AlumniContactsSearchInput />

--- a/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list/AlumniContactsList.tsx
+++ b/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list/AlumniContactsList.tsx
@@ -54,7 +54,7 @@ const AlumniContactsList = ({
 
   return (
     <ul
-      className="mb-20 grid min-h-0 flex-1 grid-cols-1 content-start gap-4 overflow-y-auto md:mb-5 md:grid-cols-2"
+      className="grid min-h-0 flex-1 grid-cols-1 content-start gap-4 overflow-y-auto md:grid-cols-2"
       ref={ref}
     >
       {data?.map((item) => (
@@ -74,6 +74,7 @@ const AlumniContactsList = ({
             <SuspenseView />
           </div>
         ))}
+      <div className="col-span-1 h-1 md:col-span-2" />
     </ul>
   );
 };

--- a/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list/AlumniContactsList.tsx
+++ b/apps/web/src/widgets/alumni-contacts/ui/alumni-contacts-list/AlumniContactsList.tsx
@@ -74,7 +74,7 @@ const AlumniContactsList = ({
             <SuspenseView />
           </div>
         ))}
-      <div className="col-span-1 h-1 md:col-span-2" />
+      <li className="col-span-1 h-1 md:col-span-2" />
     </ul>
   );
 };


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #263


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 동문수첩 메인 목록에서 항상 보이던 하단 여백을 제거하고, 목록을 끝까지 스크롤했을 때만 하단 여백이 보이도록 수정했습니다.


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- `AlumniContactsListPage`의 페이지 컨테이너 하단 padding을 제거했습니다.
- `AlumniContactsList`의 상시 bottom margin을 제거했습니다.
- 리스트 마지막에 작은 spacer를 추가해 스크롤을 끝까지 내렸을 때만 하단 여백이 보이도록 조정했습니다.


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- 모바일/PC 동문수첩 메인에서 하단 여백이 기본 노출되지 않는지 확인해주세요.
- 목록을 끝까지 스크롤했을 때 하단 탭/화면 끝과 리스트 아이템 간 간격이 자연스러운지 확인해주세요.
- 무한 스크롤 target 및 로딩 UI 노출에 영향이 없는지 확인해주세요.


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.

**수정 전**
<img width="769" height="408" alt="image" src="https://github.com/user-attachments/assets/0e7ada29-dabc-48f6-8105-285524b93227" />

**수정 후**

https://github.com/user-attachments/assets/729ac3e2-a076-42b4-a176-ff09c4e48c9e



- `pnpm --filter @causw/web lint` 통과
  - 기존 auth/image 관련 warning 5건 발생, 이번 변경 파일과는 무관합니다.
- `git diff --check develop...HEAD` 통과


## 📎 Additional Notes
- QA: 동문수첩 메인 하단에 공백이 생기지 않도록 수정
