### PR TITLE
feat: 경조사 상세 링크 섹션 추가 #262

### DIFF
--- a/apps/web/src/widgets/ceremony/ui/ceremony-detail-view/CeremonyDetailView.tsx
+++ b/apps/web/src/widgets/ceremony/ui/ceremony-detail-view/CeremonyDetailView.tsx
@@ -32,9 +32,15 @@ export const CeremonyDetailView = ({ detail }: CeremonyDetailViewProps) => {
     address,
     detailedAddress,
     contact,
+    link,
   } = detail;
 
   const showApplicant = applicant !== subject;
+  const linkHref = link
+    ? /^https?:\/\//i.test(link)
+      ? link
+      : `https://${link}`
+    : null;
 
   const handleCopyAddress = async () => {
     if (address) {
@@ -49,6 +55,12 @@ export const CeremonyDetailView = ({ detail }: CeremonyDetailViewProps) => {
     if (contact) {
       const sanitizedContact = contact.replace(/[^0-9+]/g, '');
       window.location.href = `tel:${sanitizedContact}`;
+    }
+  };
+
+  const handleOpenLink = () => {
+    if (linkHref) {
+      window.open(linkHref, '_blank', 'noopener,noreferrer');
     }
   };
 
@@ -168,6 +180,31 @@ export const CeremonyDetailView = ({ detail }: CeremonyDetailViewProps) => {
             </Text>
             <Button size="sm" color="gray" onClick={handleCall}>
               전화 걸기
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* 링크 섹션 */}
+      {linkHref && (
+        <div className="flex flex-col gap-[0.5rem]">
+          <Text
+            typography="subtitle-16-bold"
+            textColor="gray-700"
+            className="px-1"
+          >
+            링크
+          </Text>
+          <div className="flex items-center justify-between gap-[0.75rem] rounded-[0.75rem] bg-white p-5">
+            <Text
+              typography="body-16-regular"
+              textColor="gray-700"
+              className="min-w-0 wrap-break-word"
+            >
+              {link}
+            </Text>
+            <Button size="sm" color="gray" onClick={handleOpenLink}>
+              열기
             </Button>
           </div>
         </div>


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #262


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 경조사 상세페이지에서 관련 링크를 표시하고 열 수 있도록 추가했습니다.


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- 경조사 상세 응답의 `link` 값을 상세 화면에서 렌더링하도록 추가
- `http/https`가 없는 링크는 `https://`를 붙여 열리도록 처리
- 링크 열기 버튼 클릭 시 새 탭으로 이동하도록 구현


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- 링크가 문의 섹션 아래에 의도한 위치로 노출되는지
- 링크 값이 없을 때 섹션이 표시되지 않는지
- 링크 열기 동작이 모바일/웹에서 적절한지


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.
<img width="2656" height="1690" alt="localhost_3000_ceremony_a88eed18-1e07-4426-add1-4822b54cf094" src="https://github.com/user-attachments/assets/cc958af6-133e-4512-9200-10e5df4df9e5" />


## 📎 Additional Notes
-
