### PR TITLE
[FEAT/#269] 일반 게시글 하이퍼링크 기능 추가

### DIFF
--- a/apps/web/src/entities/post/config/index.ts
+++ b/apps/web/src/entities/post/config/index.ts
@@ -1,2 +1,3 @@
 export { POST_API_PREFIX } from './postApiPrefix';
 export { postQueryKeys, postQueryOptions } from './query';
+export { POST_LINKIFIED_REGEX } from './postLinkifiedRegex';

--- a/apps/web/src/entities/post/config/postLinkifiedRegex.ts
+++ b/apps/web/src/entities/post/config/postLinkifiedRegex.ts
@@ -1,0 +1,5 @@
+export const POST_LINKIFIED_REGEX = {
+  URL_SPLIT: /(https?:\/\/[^\s]+|www\.[^\s]+)/g,
+  URL_TEST: /^(https?:\/\/[^\s]+|www\.[^\s]+)$/,
+  TRAILING_PUNCTUATION: /[.,!?;:]+$/,
+};

--- a/apps/web/src/entities/post/model/hooks/index.ts
+++ b/apps/web/src/entities/post/model/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useLinkifiedText } from './useLinkifiedText';

--- a/apps/web/src/entities/post/model/hooks/useLinkifiedText.tsx
+++ b/apps/web/src/entities/post/model/hooks/useLinkifiedText.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { Fragment, useCallback, useMemo } from 'react';
+
+import { POST_LINKIFIED_REGEX } from '@/entities/post/config';
+
+const { URL_SPLIT, URL_TEST, TRAILING_PUNCTUATION } = POST_LINKIFIED_REGEX;
+interface UseLinkifiedTextProps {
+  content: string;
+  isHtml: boolean;
+}
+
+export const useLinkifiedText = ({
+  content,
+  isHtml,
+}: UseLinkifiedTextProps) => {
+  const normalizeHref = useCallback((url: string) => {
+    return url.startsWith('http://') || url.startsWith('https://')
+      ? url
+      : `https://${url}`;
+  }, []);
+
+  const trimTrailingPunctuation = useCallback((url: string) => {
+    const trailingPunctuation = url.match(TRAILING_PUNCTUATION)?.[0] ?? '';
+    const cleanUrl = trailingPunctuation
+      ? url.slice(0, -trailingPunctuation.length)
+      : url;
+
+    return {
+      cleanUrl,
+      trailingPunctuation,
+    };
+  }, []);
+
+  const linkifiedContent = useMemo(() => {
+    if (isHtml) {
+      return null;
+    }
+
+    return content.split(URL_SPLIT).map((part, index) => {
+      if (!URL_TEST.test(part)) {
+        return part;
+      }
+
+      const { cleanUrl, trailingPunctuation } = trimTrailingPunctuation(part);
+
+      return (
+        <Fragment key={`${part}-${index}`}>
+          <a
+            href={normalizeHref(cleanUrl)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            {cleanUrl}
+          </a>
+          {trailingPunctuation}
+        </Fragment>
+      );
+    });
+  }, [content, isHtml, normalizeHref, trimTrailingPunctuation]);
+
+  return {
+    linkifiedContent,
+  };
+};

--- a/apps/web/src/entities/post/model/index.ts
+++ b/apps/web/src/entities/post/model/index.ts
@@ -2,3 +2,4 @@ export * from './mock';
 export * from './form';
 export * from './queries';
 export * from './types';
+export { useLinkifiedText } from './hooks';

--- a/apps/web/src/entities/post/ui/PostBody.tsx
+++ b/apps/web/src/entities/post/ui/PostBody.tsx
@@ -1,10 +1,18 @@
 'use client';
 
-import { type RefObject, useEffect, useRef, useState } from 'react';
+import {
+  type CSSProperties,
+  type RefObject,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import { Text, VStack } from '@causw/cds';
 
 import { sanitizeHtml } from '@/shared/lib/sanitizer';
+
+import { useLinkifiedText } from '../model';
 
 import { PostImage } from './PostImage';
 
@@ -50,7 +58,7 @@ export const PostBody = ({
   const [isOverflowing, setIsOverflowing] = useState(false);
 
   const sanitizedHtml = isHtml ? sanitizeHtml(content) : '';
-  const collapseStyles = isCollapsed
+  const collapseStyles: CSSProperties | undefined = isCollapsed
     ? {
         display: '-webkit-box',
         WebkitBoxOrient: 'vertical' as const,
@@ -58,6 +66,8 @@ export const PostBody = ({
         overflow: 'hidden',
       }
     : undefined;
+
+  const { linkifiedContent } = useLinkifiedText({ content, isHtml });
 
   useEffect(() => {
     const el = textRef.current;
@@ -92,7 +102,7 @@ export const PostBody = ({
             className="break-all whitespace-pre-wrap"
             style={collapseStyles}
           >
-            {content}
+            {linkifiedContent}
           </Text>
         )}
 


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #269


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 일반 게시글 본문에 포함된 URL 문자열을 클릭 가능한 하이퍼링크로 렌더링하도록 추가했습니다.


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- 일반 게시글 plain text를 React node로 변환하는 `useLinkifiedText` 훅을 추가했습니다.
- `http://`, `https://`, `www.` 형태의 URL을 감지해 외부 링크 `<a>` 태그로 렌더링하도록 처리했습니다.
- `www.`로 시작하는 URL은 `https://`를 보정해 `href`로 사용하도록 구성했습니다.
- URL 끝에 붙은 `.,!?;:` 문장부호는 링크 밖으로 분리해 문장형 게시글에서도 자연스럽게 동작하도록 처리했습니다.
- 크롤링 HTML 게시글은 기존 `sanitizeHtml` 및 `dangerouslySetInnerHTML` 렌더링 흐름을 유지했습니다.


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- 일반 게시글 URL linkify 기준이 적절한지 확인해주세요.
- URL 끝 문장부호 후처리 범위가 과하거나 부족하지 않은지 확인해주세요.
- HTML 게시글과 일반 게시글 렌더링 분리가 기존 동작을 해치지 않는지 확인해주세요.


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.

- `pnpm --filter @causw/web lint`
  - 0 errors, 5 warnings
  - 기존 auth/image 영역의 react-hooks warning만 확인되었고, 이번 변경 파일에서는 lint error가 발생하지 않았습니다.


## 📎 Additional Notes
- 서드 파티 라이브러리 없이 정규표현식 기반으로 URL을 감지하도록 구현했습니다.
- 괄호가 포함된 URL이 깨지는 문제를 줄이기 위해 trailing punctuation 후처리 대상에서 `)`, `]`, `}`는 제외했습니다.
