### PR TITLE
[FIX/#276] 인증 관련 QA 사항 반영

### DIFF
--- a/apps/web/src/_pages/auth/reset-password/ResetPasswordPage.tsx
+++ b/apps/web/src/_pages/auth/reset-password/ResetPasswordPage.tsx
@@ -1,26 +1,88 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+
 import { useRouter } from 'next/navigation';
 
 import { VStack } from '@causw/cds';
 
 import { AuthContainer } from '@/widgets/auth';
 
-import { ResetPasswordForm } from '@/features/auth';
+import {
+  clearPasswordResetContext,
+  getPasswordResetContext,
+  resetPassword,
+  ResetPasswordForm,
+  type PasswordResetContext,
+} from '@/features/auth';
 
 import type { ResetPasswordFormData } from '@/entities/auth';
 
 import { toast } from '@/shared/model';
 import { ActionHeader } from '@/shared/ui';
+import { extractErrorMessage } from '@/shared/utils';
 
 export const ResetPasswordPage = () => {
   const router = useRouter();
+  const [resetContext, setResetContext] = useState<PasswordResetContext | null>(
+    null,
+  );
+  const [isLoadingContext, setIsLoadingContext] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // TODO: API 연동 후 실제 비밀번호 변경 로직으로 교체
-  const handleSubmit = (_data: ResetPasswordFormData) => {
-    toast.success('비밀번호 변경이 완료되었습니다.');
-    router.replace('/auth/sign-in/email');
+  useEffect(() => {
+    const context = getPasswordResetContext();
+
+    if (!context) {
+      setIsLoadingContext(false);
+      toast.error(
+        '임시 비밀번호 정보가 없습니다. 다시 비밀번호 찾기를 진행해 주세요.',
+      );
+      router.replace('/auth/find-account');
+      return;
+    }
+
+    setResetContext(context);
+    setIsLoadingContext(false);
+  }, [router]);
+
+  const handleClose = () => {
+    clearPasswordResetContext();
+    router.replace('/auth/sign-in');
   };
+
+  const handleSubmit = async (data: ResetPasswordFormData) => {
+    if (!resetContext || isSubmitting) return;
+
+    setIsSubmitting(true);
+    toast.loading('비밀번호를 변경하고 있어요...');
+
+    try {
+      await resetPassword({
+        email: resetContext.email,
+        currentPassword: resetContext.temporaryPassword,
+        newPassword: data.newPassword,
+        newPasswordConfirm: data.confirmPassword,
+      });
+
+      clearPasswordResetContext();
+      toast.success('비밀번호 변경이 완료되었습니다.');
+      router.replace('/auth/sign-in/email');
+    } catch (error) {
+      toast.error(
+        extractErrorMessage(
+          error,
+          '비밀번호 변경에 실패했습니다. 다시 시도해 주세요.',
+        ),
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isLoadingContext || !resetContext) {
+    return null;
+  }
 
   return (
     <AuthContainer>
@@ -31,14 +93,15 @@ export const ResetPasswordPage = () => {
           buttonColor="gray"
           className="px-0"
         >
-          <ActionHeader.BackButton
-            onClick={() => router.replace('/auth/sign-in')}
-          >
+          <ActionHeader.BackButton onClick={handleClose}>
             닫기
           </ActionHeader.BackButton>
         </ActionHeader>
 
-        <ResetPasswordForm onSubmit={handleSubmit} />
+        <ResetPasswordForm
+          onSubmit={handleSubmit}
+          isSubmitting={isSubmitting}
+        />
       </VStack>
     </AuthContainer>
   );

--- a/apps/web/src/_pages/setting/password/SettingPasswordPage.tsx
+++ b/apps/web/src/_pages/setting/password/SettingPasswordPage.tsx
@@ -9,7 +9,7 @@ import { usePasswordChangeForm } from '@/features/setting';
 import { ActionHeader, RHFPasswordInput } from '@/shared/ui';
 
 export const SettingPasswordPage = () => {
-  const { methods, onSubmit, isSubmitting } = usePasswordChangeForm();
+  const { methods, onSubmit, isReady, isSubmitting } = usePasswordChangeForm();
 
   return (
     <VStack className="w-full">
@@ -46,7 +46,7 @@ export const SettingPasswordPage = () => {
               color="dark"
               fullWidth
               type="submit"
-              disabled={!methods.formState.isValid || isSubmitting}
+              disabled={!methods.formState.isValid || !isReady || isSubmitting}
             >
               {isSubmitting ? '변경 중...' : '변경하기'}
             </CTAButton>

--- a/apps/web/src/entities/auth/model/form/enrollment/schema.ts
+++ b/apps/web/src/entities/auth/model/form/enrollment/schema.ts
@@ -32,10 +32,7 @@ export const enrollmentVerificationSchema = z
       .min(1, '학과를 선택해주세요.'),
     [ENROLLMENT_VERIFICATION_FORM_FIELD.enrollmentYear]: yearSchema('입학년도'),
     [ENROLLMENT_VERIFICATION_FORM_FIELD.graduationYear]: z.string().optional(),
-    [ENROLLMENT_VERIFICATION_FORM_FIELD.studentId]: z
-      .string()
-      .min(1, '학번을 입력해주세요.')
-      .regex(/^\d+$/, '학번은 숫자만 입력 가능합니다.'),
+    [ENROLLMENT_VERIFICATION_FORM_FIELD.studentId]: z.string().optional(),
     [ENROLLMENT_VERIFICATION_FORM_FIELD.enrollmentState]: z
       .string()
       .min(1, '재학 분류를 선택해주세요.'),
@@ -50,6 +47,9 @@ export const enrollmentVerificationSchema = z
   })
   .superRefine((data, ctx) => {
     const images = data[ENROLLMENT_VERIFICATION_FORM_FIELD.images];
+    const enrollmentState =
+      data[ENROLLMENT_VERIFICATION_FORM_FIELD.enrollmentState];
+    const studentId = data[ENROLLMENT_VERIFICATION_FORM_FIELD.studentId];
 
     if (!images || images.length === 0) {
       ctx.addIssue({
@@ -71,10 +71,28 @@ export const enrollmentVerificationSchema = z
     }
 
     if (
-      data[ENROLLMENT_VERIFICATION_FORM_FIELD.enrollmentState] !==
+      enrollmentState !==
       ENROLLMENT_VERIFICATION_ACADEMIC_STATUS.GRADUATED.value
-    )
+    ) {
+      if (!studentId) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [ENROLLMENT_VERIFICATION_FORM_FIELD.studentId],
+          message: '학번을 입력해주세요.',
+        });
+        return;
+      }
+
+      if (!/^\d+$/.test(studentId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [ENROLLMENT_VERIFICATION_FORM_FIELD.studentId],
+          message: '학번은 숫자만 입력 가능합니다.',
+        });
+      }
+
       return;
+    }
 
     const result = yearSchema('졸업년도').safeParse(
       data[ENROLLMENT_VERIFICATION_FORM_FIELD.graduationYear],

--- a/apps/web/src/entities/auth/model/form/sign-in/schema.ts
+++ b/apps/web/src/entities/auth/model/form/sign-in/schema.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
 
-import { emailSchema, passwordSchema } from '@/shared/model';
+import { emailSchema } from '@/shared/model';
 
 export const signInSchema = z.object({
   email: emailSchema,
-  password: passwordSchema,
+  password: z.string().min(1, '비밀번호를 입력해주세요.'),
   rememberMe: z.boolean().optional(),
 });
 

--- a/apps/web/src/entities/auth/model/types/types.ts
+++ b/apps/web/src/entities/auth/model/types/types.ts
@@ -153,6 +153,13 @@ export interface PasswordResetVerifyResponseDto {
   temporaryPassword: string;
 }
 
+export interface PasswordResetChangeRequestDto {
+  email: string;
+  currentPassword: string;
+  newPassword: string;
+  newPasswordConfirm: string;
+}
+
 export type AdmissionDepartment =
   | 'DEPT_OF_AI'
   | 'SCHOOL_OF_SW'

--- a/apps/web/src/entities/auth/model/types/types.ts
+++ b/apps/web/src/entities/auth/model/types/types.ts
@@ -166,7 +166,7 @@ export interface AdmissionCreateRequestPayloadDto {
   name: string;
   requestedDepartment: AdmissionDepartment;
   requestedAdmissionYear: number;
-  requestedStudentId: string;
+  requestedStudentId: string | null;
   requestedAcademicStatus: AdmissionAcademicStatus;
   graduationYear?: number;
   description?: string;

--- a/apps/web/src/entities/setting/model/types/types.ts
+++ b/apps/web/src/entities/setting/model/types/types.ts
@@ -10,6 +10,7 @@ export type MyActivityFeed = {
 };
 
 export interface PasswordChangeRequest {
+  email: string;
   currentPassword: string;
   newPassword: string;
   newPasswordConfirm: string;

--- a/apps/web/src/features/auth/api/post/session.ts
+++ b/apps/web/src/features/auth/api/post/session.ts
@@ -14,11 +14,12 @@ import type {
   PasswordResetSendRequestDto,
   PasswordResetVerifyRequestDto,
   PasswordResetVerifyResponseDto,
+  PasswordResetChangeRequestDto,
   TermsAgreementRequestDto,
 } from '@/entities/auth';
 
 import { API } from '@/shared/api';
-import { AUTH_API_PREFIX } from '@/shared/constants';
+import { AUTH_API_PREFIX, USER_API_PREFIX } from '@/shared/constants';
 import { TokenManager } from '@/shared/storage';
 
 export const signup = async (data: SignupRequestDto) => {
@@ -85,6 +86,10 @@ export const verifyPasswordResetCode = async (
     `${AUTH_API_PREFIX}/password-reset/verify`,
     data,
   );
+};
+
+export const resetPassword = async (data: PasswordResetChangeRequestDto) => {
+  return API.post<null>(`${USER_API_PREFIX}/password-change`, data);
 };
 
 export const agreeTerms = async (data: TermsAgreementRequestDto) => {

--- a/apps/web/src/features/auth/lib/index.ts
+++ b/apps/web/src/features/auth/lib/index.ts
@@ -2,3 +2,4 @@ export { routeAfterSignIn } from './routeAfterSignIn';
 export { resetAuthAndRouteToSignIn } from './resetAuthAndRouteToSignIn';
 export { useKakaoSDK } from './useKakaoSDK';
 export { getSocialOauthUrl } from './getSocialOauthUrl';
+export * from './passwordResetContext';

--- a/apps/web/src/features/auth/lib/passwordResetContext.ts
+++ b/apps/web/src/features/auth/lib/passwordResetContext.ts
@@ -1,0 +1,58 @@
+'use client';
+
+const PASSWORD_RESET_CONTEXT_KEY = 'password-reset-context';
+
+export interface PasswordResetContext {
+  email: string;
+  temporaryPassword: string;
+}
+
+const isPasswordResetContext = (
+  value: unknown,
+): value is PasswordResetContext => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const context = value as Record<string, unknown>;
+
+  return (
+    typeof context.email === 'string' &&
+    context.email.length > 0 &&
+    typeof context.temporaryPassword === 'string' &&
+    context.temporaryPassword.length > 0
+  );
+};
+
+export const setPasswordResetContext = (context: PasswordResetContext) => {
+  if (typeof window === 'undefined') return;
+
+  window.sessionStorage.setItem(
+    PASSWORD_RESET_CONTEXT_KEY,
+    JSON.stringify(context),
+  );
+};
+
+export const getPasswordResetContext = (): PasswordResetContext | null => {
+  if (typeof window === 'undefined') return null;
+
+  const raw = window.sessionStorage.getItem(PASSWORD_RESET_CONTEXT_KEY);
+
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+
+    return isPasswordResetContext(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+export const clearPasswordResetContext = () => {
+  if (typeof window === 'undefined') return;
+
+  window.sessionStorage.removeItem(PASSWORD_RESET_CONTEXT_KEY);
+};

--- a/apps/web/src/features/auth/model/form/useEnrollmentVerificationForm.ts
+++ b/apps/web/src/features/auth/model/form/useEnrollmentVerificationForm.ts
@@ -7,6 +7,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useSubmitAdmissionMutation } from '@/features/auth';
 
 import {
+  ENROLLMENT_VERIFICATION_ACADEMIC_STATUS,
   enrollmentVerificationSchema,
   type AdmissionAcademicStatus,
   type AdmissionDepartment,
@@ -38,12 +39,17 @@ export const useEnrollmentVerificationForm = ({
   });
 
   const handleSubmit = (data: EnrollmentVerificationFormData) => {
+    const isGraduated =
+      data.enrollmentState ===
+      ENROLLMENT_VERIFICATION_ACADEMIC_STATUS.GRADUATED.value;
+    const requestedStudentId = isGraduated ? null : (data.studentId ?? '');
+
     submitAdmissionMutation.mutate({
       request: {
         name: userName,
         requestedDepartment: data.major as AdmissionDepartment,
         requestedAdmissionYear: Number(data.enrollmentYear),
-        requestedStudentId: data.studentId,
+        requestedStudentId,
         requestedAcademicStatus:
           data.enrollmentState as AdmissionAcademicStatus,
         graduationYear: data.graduationYear

--- a/apps/web/src/features/auth/ui/enrollment-verification-student-id-field/EnrollmentVerificationStudentIdField.tsx
+++ b/apps/web/src/features/auth/ui/enrollment-verification-student-id-field/EnrollmentVerificationStudentIdField.tsx
@@ -1,10 +1,25 @@
 'use client';
 
-import { ENROLLMENT_VERIFICATION_FORM_FIELD } from '@/entities/auth';
+import { useWatch } from 'react-hook-form';
+
+import {
+  ENROLLMENT_VERIFICATION_ACADEMIC_STATUS,
+  ENROLLMENT_VERIFICATION_FORM_FIELD,
+} from '@/entities/auth';
 
 import { RHFInput } from '@/shared/ui';
 
 export const EnrollmentVerificationStudentIdField = () => {
+  const enrollmentState = useWatch({
+    name: ENROLLMENT_VERIFICATION_FORM_FIELD.enrollmentState,
+  });
+
+  if (
+    enrollmentState === ENROLLMENT_VERIFICATION_ACADEMIC_STATUS.GRADUATED.value
+  ) {
+    return null;
+  }
+
   return (
     <RHFInput
       label="학번"

--- a/apps/web/src/features/auth/ui/reset-password-form/ResetPasswordForm.tsx
+++ b/apps/web/src/features/auth/ui/reset-password-form/ResetPasswordForm.tsx
@@ -15,9 +15,13 @@ import { RHFPasswordInput } from '@/shared/ui';
 
 interface ResetPasswordFormProps {
   onSubmit: (data: ResetPasswordFormData) => void;
+  isSubmitting?: boolean;
 }
 
-export const ResetPasswordForm = ({ onSubmit }: ResetPasswordFormProps) => {
+export const ResetPasswordForm = ({
+  onSubmit,
+  isSubmitting = false,
+}: ResetPasswordFormProps) => {
   const methods = useForm<ResetPasswordFormData>({
     resolver: zodResolver(resetPasswordSchema),
     mode: 'onChange',
@@ -62,8 +66,13 @@ export const ResetPasswordForm = ({ onSubmit }: ResetPasswordFormProps) => {
           />
         </VStack>
 
-        <CTAButton color="dark" fullWidth type="submit" disabled={!isValid}>
-          비밀번호 변경
+        <CTAButton
+          color="dark"
+          fullWidth
+          type="submit"
+          disabled={!isValid || isSubmitting}
+        >
+          {isSubmitting ? '변경 중...' : '비밀번호 변경'}
         </CTAButton>
       </VStack>
     </FormProvider>

--- a/apps/web/src/features/setting/api/post/user.ts
+++ b/apps/web/src/features/setting/api/post/user.ts
@@ -4,5 +4,5 @@ import { API } from '@/shared/api';
 import { USER_API_PREFIX } from '@/shared/constants';
 
 export const changeMyPassword = async (data: PasswordChangeRequest) => {
-  return API.post<null>(`${USER_API_PREFIX}/me/password-change`, data);
+  return API.post<null>(`${USER_API_PREFIX}/password-change`, data);
 };

--- a/apps/web/src/features/setting/model/form/usePasswordChangeForm.ts
+++ b/apps/web/src/features/setting/model/form/usePasswordChangeForm.ts
@@ -3,7 +3,9 @@
 import { useForm } from 'react-hook-form';
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useQuery } from '@tanstack/react-query';
 
+import { authQueryOptions } from '@/entities/auth';
 import {
   passwordChangeFormSchema,
   type PasswordChangeFormData,
@@ -12,6 +14,7 @@ import {
 import { useChangeMyPasswordMutation } from '../mutations';
 
 export const usePasswordChangeForm = () => {
+  const { data: me } = useQuery(authQueryOptions.me());
   const methods = useForm<PasswordChangeFormData>({
     mode: 'onChange',
     resolver: zodResolver(passwordChangeFormSchema),
@@ -28,7 +31,12 @@ export const usePasswordChangeForm = () => {
   });
 
   const onSubmit = (data: PasswordChangeFormData) => {
+    if (!me?.email) {
+      return;
+    }
+
     changePasswordMutation.mutate({
+      email: me.email,
       currentPassword: data.currentPassword,
       newPassword: data.nextPassword,
       newPasswordConfirm: data.confirmPassword,
@@ -38,6 +46,7 @@ export const usePasswordChangeForm = () => {
   return {
     methods,
     onSubmit,
+    isReady: !!me?.email,
     isSubmitting: changePasswordMutation.isPending,
   };
 };

--- a/apps/web/src/shared/constants/auth/publicEndpoints.ts
+++ b/apps/web/src/shared/constants/auth/publicEndpoints.ts
@@ -14,6 +14,7 @@ export const PUBLIC_ENDPOINTS: PublicEndpoint[] = [
   { method: 'POST', path: `${AUTH_API_PREFIX}/find-email` },
   { method: 'POST', path: `${AUTH_API_PREFIX}/password-reset/send` },
   { method: 'POST', path: `${AUTH_API_PREFIX}/password-reset/verify` },
+  { method: 'POST', path: `${USER_API_PREFIX}/password-change` },
   { method: 'POST', path: `${AUTH_API_PREFIX}/login/native` },
   { method: 'GET', path: '/api/v2/terms' },
   { method: 'GET', path: `${USER_API_PREFIX}/check-nickname` },

--- a/apps/web/src/widgets/auth/ui/temporary-password-issued/TemporaryPasswordIssued.tsx
+++ b/apps/web/src/widgets/auth/ui/temporary-password-issued/TemporaryPasswordIssued.tsx
@@ -4,6 +4,11 @@ import { useRouter } from 'next/navigation';
 
 import { Button, CTAButton, HStack, Text, VStack } from '@causw/cds';
 
+import {
+  clearPasswordResetContext,
+  setPasswordResetContext,
+} from '@/features/auth';
+
 import { toast } from '@/shared/model';
 
 interface TemporaryPasswordIssuedProps {
@@ -27,6 +32,16 @@ export const TemporaryPasswordIssued = ({
   const handleCopy = async () => {
     await navigator.clipboard.writeText(temporaryPassword);
     toast.success('비밀번호가 복사되었습니다.');
+  };
+
+  const handleSignIn = () => {
+    clearPasswordResetContext();
+    router.push('/auth/sign-in');
+  };
+
+  const handleResetPassword = () => {
+    setPasswordResetContext({ email, temporaryPassword });
+    router.replace('/auth/reset-password');
   };
 
   return (
@@ -68,17 +83,13 @@ export const TemporaryPasswordIssued = ({
       </VStack>
 
       <HStack className="w-full gap-2">
-        <CTAButton
-          color="white"
-          className="flex-1"
-          onClick={() => router.push('/auth/sign-in')}
-        >
+        <CTAButton color="white" className="flex-1" onClick={handleSignIn}>
           로그인
         </CTAButton>
         <CTAButton
           color="dark"
           className="flex-1"
-          onClick={() => router.replace('/auth/reset-password')}
+          onClick={handleResetPassword}
         >
           비밀번호 재설정
         </CTAButton>


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #276 
- Closes #277 


## 📝 Description

인증 관련 QA 사항과 재학증빙 제출 정책 변경을 반영했습니다.

- 비밀번호 찾기 후 재설정이 실제 API를 호출하도록 수정
- 로그인 폼에서 기존 사용자 로그인을 막던 비밀번호 복잡도 검증 제거
- 재학증빙 서류 제출 시 졸업생의 경우 학번을 nullable하게 처리하고 입력 필드를 숨기도록 변경

## 🛠️ Changes

- 비밀번호 재설정 API를 `POST /api/v2/users/password-change` 기준으로 반영했습니다.
- 비밀번호 찾기 후 재설정 화면에서 이메일과 임시 비밀번호를 이용해 바로 비밀번호를 변경할 수 있도록 수정했습니다.
- 비로그인 상태에서도 비밀번호 재설정 API를 호출할 수 있도록 public endpoint에 추가했습니다.
- 설정 페이지의 비밀번호 변경도 동일한 `POST /api/v2/users/password-change` API를 사용하도록 통일했습니다.
- 기존 `POST /api/v2/users/me/password-change` 경로 사용을 제거했습니다.
- 로그인 폼 비밀번호 검증을 공용 `passwordSchema`에서 분리하고, 빈 값만 검증하도록 완화했습니다.
- 재학증빙 제출 폼에서 `재학 분류 = 졸업`인 경우:
  - 학번 필드를 화면에 노출하지 않도록 변경
  - 학번 validation을 필수에서 제외
  - 요청 payload의 `requestedStudentId`를 `null`로 전송하도록 변경


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.


## 📎 Additional Notes
-
