### PR TITLE
[FEAT/#287] 게시글 목록 페이지 게시판 조회 API 스펙 변경 대응

### DIFF
--- a/apps/web/src/_pages/feed/FeedPage.tsx
+++ b/apps/web/src/_pages/feed/FeedPage.tsx
@@ -12,7 +12,6 @@ export const FeedPage = () => {
       <VStack className="min-h-0 w-full py-4 md:px-8 md:py-6 xl:w-225">
         <VStack className="min-h-0 flex-1 gap-3">
           <FeedHeader />
-
           <QueryErrorBoundary fallbackMessage="게시글 목록을 불러오지 못했어요.">
             <Suspense fallback={<SuspenseView />}>
               <FeedMainServerComponent />

--- a/apps/web/src/entities/feed/api/get.ts
+++ b/apps/web/src/entities/feed/api/get.ts
@@ -1,20 +1,26 @@
 import { API } from '@/shared/api';
+import { createQueryString, withQuery } from '@/shared/utils';
 
+import { BOARDS_API_PREFIX } from '../config';
 import {
   type GetWritableBoardListResponseDto,
   type GetAvailableBoardListResponseDto,
+  type GetAvailableBoardListQuery,
 } from '../model';
 
-export const getAvailableBoards = async () => {
-  const response = await API.get<GetAvailableBoardListResponseDto>(
-    '/api/v2/boards/available',
+export const getAvailableBoards = async (query: GetAvailableBoardListQuery) => {
+  const url = withQuery(
+    `${BOARDS_API_PREFIX}/available`,
+    createQueryString(query),
   );
+
+  const response = await API.get<GetAvailableBoardListResponseDto>(url);
   return response;
 };
 
 export const getWritableBoards = async () => {
   const response = await API.get<GetWritableBoardListResponseDto>(
-    '/api/v2/boards/writable',
+    `${BOARDS_API_PREFIX}/writable`,
   );
   return response;
 };

--- a/apps/web/src/entities/feed/api/get.ts
+++ b/apps/web/src/entities/feed/api/get.ts
@@ -8,7 +8,9 @@ import {
   type GetAvailableBoardListQuery,
 } from '../model';
 
-export const getAvailableBoards = async (query: GetAvailableBoardListQuery) => {
+export const getAvailableBoards = async (
+  query: GetAvailableBoardListQuery = {},
+) => {
   const url = withQuery(
     `${BOARDS_API_PREFIX}/available`,
     createQueryString(query),

--- a/apps/web/src/entities/feed/config/boardApiPrefix.ts
+++ b/apps/web/src/entities/feed/config/boardApiPrefix.ts
@@ -1,0 +1,1 @@
+export const BOARDS_API_PREFIX = '/api/v2/boards';

--- a/apps/web/src/entities/feed/config/index.ts
+++ b/apps/web/src/entities/feed/config/index.ts
@@ -13,3 +13,4 @@ export {
   normalizeMyFeedView,
 } from './myFeedView';
 export { FEED_SCROLL_RESTORATION_STORAGE_KEY } from './feedScrollRestorationStorageKey';
+export { BOARDS_API_PREFIX } from './boardApiPrefix';

--- a/apps/web/src/entities/feed/config/query/boardQueryKeys.ts
+++ b/apps/web/src/entities/feed/config/query/boardQueryKeys.ts
@@ -1,5 +1,8 @@
+import { type GetAvailableBoardListQuery } from '../../model';
+
 export const boardQueryKeys = {
   all: ['boards'] as const,
-  available: () => [...boardQueryKeys.all, 'available'] as const,
+  available: (query: GetAvailableBoardListQuery) =>
+    [...boardQueryKeys.all, 'available', query] as const,
   writable: () => [...boardQueryKeys.all, 'writable'] as const,
 };

--- a/apps/web/src/entities/feed/config/query/boardQueryOptions.ts
+++ b/apps/web/src/entities/feed/config/query/boardQueryOptions.ts
@@ -3,14 +3,15 @@ import { queryOptions } from '@tanstack/react-query';
 import { QUERY_STALE_TIME } from '@/shared/constants';
 
 import { getAvailableBoards, getWritableBoards } from '../../api';
+import { type GetAvailableBoardListQuery } from '../../model';
 
 import { boardQueryKeys } from './boardQueryKeys';
 
 export const boardQueryOptions = {
-  available: () =>
+  available: (query: GetAvailableBoardListQuery) =>
     queryOptions({
-      queryKey: boardQueryKeys.available(),
-      queryFn: getAvailableBoards,
+      queryKey: boardQueryKeys.available(query),
+      queryFn: () => getAvailableBoards(query),
       staleTime: QUERY_STALE_TIME.DEFAULT,
       throwOnError: true,
     }),

--- a/apps/web/src/entities/feed/config/query/boardQueryOptions.ts
+++ b/apps/web/src/entities/feed/config/query/boardQueryOptions.ts
@@ -8,7 +8,7 @@ import { type GetAvailableBoardListQuery } from '../../model';
 import { boardQueryKeys } from './boardQueryKeys';
 
 export const boardQueryOptions = {
-  available: (query: GetAvailableBoardListQuery) =>
+  available: (query: GetAvailableBoardListQuery = {}) =>
     queryOptions({
       queryKey: boardQueryKeys.available(query),
       queryFn: () => getAvailableBoards(query),

--- a/apps/web/src/entities/feed/model/index.ts
+++ b/apps/web/src/entities/feed/model/index.ts
@@ -3,6 +3,7 @@ export type {
   Board,
   GetAvailableBoardListResponseDto,
   GetWritableBoardListResponseDto,
+  GetAvailableBoardListQuery,
 } from './types';
 export {
   useFeedSearchKeyword,

--- a/apps/web/src/entities/feed/model/queries/useGetAvailableBoards.ts
+++ b/apps/web/src/entities/feed/model/queries/useGetAvailableBoards.ts
@@ -4,6 +4,12 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { boardQueryOptions } from '../../config';
 
-export const useGetAvailableBoards = () => {
-  return useSuspenseQuery(boardQueryOptions.available());
+interface UseGetAvailableBoardsProps {
+  isTab?: boolean;
+}
+
+export const useGetAvailableBoards = ({
+  isTab = false,
+}: UseGetAvailableBoardsProps) => {
+  return useSuspenseQuery(boardQueryOptions.available({ isTab }));
 };

--- a/apps/web/src/entities/feed/model/queries/useGetAvailableBoards.ts
+++ b/apps/web/src/entities/feed/model/queries/useGetAvailableBoards.ts
@@ -9,7 +9,7 @@ interface UseGetAvailableBoardsProps {
 }
 
 export const useGetAvailableBoards = ({
-  isTab = false,
-}: UseGetAvailableBoardsProps) => {
+  isTab,
+}: UseGetAvailableBoardsProps = {}) => {
   return useSuspenseQuery(boardQueryOptions.available({ isTab }));
 };

--- a/apps/web/src/entities/feed/model/types/index.ts
+++ b/apps/web/src/entities/feed/model/types/index.ts
@@ -3,3 +3,4 @@ export type {
   GetAvailableBoardListResponseDto,
   GetWritableBoardListResponseDto,
 } from './dto';
+export type { GetAvailableBoardListQuery } from './query';

--- a/apps/web/src/entities/feed/model/types/query/getAvailableBoardListQuery.ts
+++ b/apps/web/src/entities/feed/model/types/query/getAvailableBoardListQuery.ts
@@ -1,0 +1,3 @@
+export interface GetAvailableBoardListQuery {
+  isTab?: boolean;
+}

--- a/apps/web/src/entities/feed/model/types/query/index.ts
+++ b/apps/web/src/entities/feed/model/types/query/index.ts
@@ -1,0 +1,1 @@
+export type { GetAvailableBoardListQuery } from './getAvailableBoardListQuery';

--- a/apps/web/src/features/post/model/mutations/useCreatePostMutation.ts
+++ b/apps/web/src/features/post/model/mutations/useCreatePostMutation.ts
@@ -11,6 +11,7 @@ import {
 } from '@/entities/post';
 
 import { toast } from '@/shared/model';
+import { extractErrorMessage } from '@/shared/utils';
 
 import { createPost } from '../../api';
 
@@ -34,8 +35,8 @@ export const useCreatePostMutation = () => {
         router.push(`/feed/${data.id}`);
       });
     },
-    onError: () => {
-      toast.error('게시글 작성에 실패했어요.');
+    onError: (error) => {
+      toast.error(extractErrorMessage(error, '게시글 작성에 실패했어요.'));
     },
   });
 };

--- a/apps/web/src/widgets/feed/model/hooks/useFeedMain.ts
+++ b/apps/web/src/widgets/feed/model/hooks/useFeedMain.ts
@@ -11,7 +11,7 @@ import { useBreakpoint } from '@/shared/hooks';
 import { FEED_LIST_TAB, FEED_LIST_TAB_SEARCH_PARAM_KEY } from '../../config';
 
 export const useFeedMain = () => {
-  const { data } = useGetAvailableBoards();
+  const { data } = useGetAvailableBoards({ isTab: true });
 
   const router = useRouter();
   const pathname = usePathname();

--- a/apps/web/src/widgets/feed/ui/feed-main/FeedMainServerComponent.tsx
+++ b/apps/web/src/widgets/feed/ui/feed-main/FeedMainServerComponent.tsx
@@ -19,7 +19,7 @@ export const FeedMainServerComponent = async () => {
     },
   });
 
-  await queryClient.prefetchQuery(boardQueryOptions.available());
+  await queryClient.prefetchQuery(boardQueryOptions.available({ isTab: true }));
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #287


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 게시글 목록 상단 탭의 게시판 조회 API에 `isTab=true` 쿼리 파라미터를 적용하고, 게시글 작성 실패 시 서버 에러 메시지를 노출하도록 수정했습니다.


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- `/api/v2/boards` API prefix 상수를 추가해 available/writable 게시판 API 경로를 정리했습니다.
- `GetAvailableBoardListQuery` 타입을 추가하고, available 게시판 조회 query key가 query 조건별로 분리되도록 변경했습니다.
- 게시글 목록 상단 탭에서 사용하는 서버 prefetch/client query에 `isTab=true`를 전달하도록 수정했습니다.
- 검색 등 전체 접근 가능 게시판이 필요한 기존 available 조회는 query 없이 호출할 수 있도록 기본값을 유지했습니다.
- 게시글 작성 실패 토스트에서 `extractErrorMessage`를 사용해 백엔드에서 내려준 에러 메시지를 우선 노출하도록 수정했습니다.


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- 게시글 목록 상단 탭 조회에서만 `isTab=true`가 적용되는지 확인해주세요.
- 검색 결과 조회 등 전체 available 게시판 목록이 필요한 흐름이 기존처럼 query 없이 동작하는지 확인해주세요.
- 비익명 게시판에서 익명 게시글 작성 시 서버 에러 메시지가 토스트로 노출되는지 확인해주세요.


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료
- [x] `pnpm --filter @causw/web lint` 완료
- [x] `pnpm --filter @causw/web build` 완료

> Storybook 검증은 게시판 API 호출 및 mutation 에러 처리 변경이라 별도로 수행하지 않았습니다.


## 📎 Additional Notes
- 관련 백엔드 PR: https://github.com/CAUCSE/CAUSW_backend/pull/1350
