### PR TITLE
[FEAT/#289] 피드 목록 게시글 본문 12줄 제한 적용

### DIFF
--- a/apps/web/src/widgets/feed/config/feedContentMaxLine.ts
+++ b/apps/web/src/widgets/feed/config/feedContentMaxLine.ts
@@ -1,0 +1,1 @@
+export const FEED_CONTENT_MAX_LINE = 12;

--- a/apps/web/src/widgets/feed/config/index.ts
+++ b/apps/web/src/widgets/feed/config/index.ts
@@ -3,3 +3,4 @@ export {
   type FeedListTab,
   FEED_LIST_TAB_SEARCH_PARAM_KEY,
 } from './feedListTab';
+export { FEED_CONTENT_MAX_LINE } from './feedContentMaxLine';

--- a/apps/web/src/widgets/feed/model/hooks/usePostListItem.ts
+++ b/apps/web/src/widgets/feed/model/hooks/usePostListItem.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { type KeyboardEvent, type MouseEvent } from 'react';
+import { useState, type KeyboardEvent, type MouseEvent } from 'react';
 
 import { useRouter } from 'next/navigation';
 
@@ -22,6 +22,12 @@ export const usePostListItem = () => {
       initializeWithValue: false,
     },
   );
+
+  const [isExpanded, setIsExpanded] = useState<boolean>(false);
+
+  const handleExpand = () => {
+    setIsExpanded(true);
+  };
 
   const moveToPost = (postId: PostResponseDto['postId']) => {
     setScrollRestoration(postId);
@@ -57,5 +63,7 @@ export const usePostListItem = () => {
   return {
     handleCardClick,
     handleCardKeyDown,
+    isExpanded,
+    handleExpand,
   };
 };

--- a/apps/web/src/widgets/feed/ui/feed-list-item/FeedListitem.tsx
+++ b/apps/web/src/widgets/feed/ui/feed-list-item/FeedListitem.tsx
@@ -19,6 +19,7 @@ import {
 
 import { ConfirmModal } from '@/shared/ui';
 
+import { FEED_CONTENT_MAX_LINE } from '../../config';
 import { usePostListItem } from '../../model';
 
 interface FeedListitemProps {
@@ -35,7 +36,8 @@ export const FeedListitem = ({ post }: FeedListitemProps) => {
     submitDelete,
   } = usePostMenuActions(post.postId);
 
-  const { handleCardClick, handleCardKeyDown } = usePostListItem();
+  const { handleCardClick, handleCardKeyDown, isExpanded, handleExpand } =
+    usePostListItem();
 
   return (
     <VStack className="relative" id={post.postId}>
@@ -61,6 +63,10 @@ export const FeedListitem = ({ post }: FeedListitemProps) => {
           images={post.postImageUrls}
           enableImageViewer={false}
           isHtml={post.isCrawled}
+          isCollapsed={!isExpanded}
+          onExpand={handleExpand}
+          showExpandButton
+          maxLines={FEED_CONTENT_MAX_LINE}
         />
         <PostFooter
           numLike={post.numLike}


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #289


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 피드 목록 게시글 본문이 최대 12줄까지만 노출되도록 접기 처리를 적용했습니다.


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- `FEED_CONTENT_MAX_LINE` 상수를 추가해 피드 본문 최대 노출 줄 수를 관리하도록 했습니다.
- `FeedListitem`에서 `PostBody`에 `isCollapsed`, `maxLines`, `showExpandButton`, `onExpand` props를 전달하도록 변경했습니다.
- `usePostListItem`에서 피드 카드별 본문 확장 상태와 `더보기` 핸들러를 관리하도록 했습니다.


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- `더보기` 클릭 시 카드 상세 이동 이벤트와 충돌하지 않는지 확인해주세요.
- 일반 텍스트/HTML 크롤링 게시글 모두에서 12줄 제한이 의도대로 적용되는지 확인해주세요.
- 피드 카드 내 이미지/푸터 레이아웃이 본문 접기 상태와 함께 자연스럽게 유지되는지 확인해주세요.


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료
- [x] `pnpm --filter @causw/web lint` 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.

- lint 결과: 0 errors, 5 warnings (기존 auth/shared 영역 warning)


## 📎 Additional Notes
- GitHub Issue #289 대응 작업입니다.
- Storybook 관련 스크립트는 이번 변경 범위에서 별도 실행하지 않았습니다.
