### PR TITLE
[FEAT/#295] 모바일 환경에서 텍스트 선택 안되게 변경하기

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -65,7 +65,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body className={`antialiased`}>
+      <body className="antialiased select-none md:select-text">
         <MSWComponent>
           <QueryProviderWithDevtools>
             <Toaster />

--- a/apps/web/src/entities/post/model/hooks/useLinkifiedText.tsx
+++ b/apps/web/src/entities/post/model/hooks/useLinkifiedText.tsx
@@ -45,12 +45,12 @@ export const useLinkifiedText = ({
       const { cleanUrl, trailingPunctuation } = trimTrailingPunctuation(part);
 
       return (
-        <Fragment key={`${part}-${index}`}>
+        <Fragment key={index}>
           <a
             href={normalizeHref(cleanUrl)}
             target="_blank"
             rel="noopener noreferrer"
-            className="underline"
+            className="text-blue-600 underline"
           >
             {cleanUrl}
           </a>

--- a/apps/web/src/entities/post/ui/PostBody.tsx
+++ b/apps/web/src/entities/post/ui/PostBody.tsx
@@ -91,7 +91,7 @@ export const PostBody = ({
             dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
             suppressHydrationWarning
             style={collapseStyles}
-            className="break-all [&_a]:break-all [&_img]:h-auto [&_img]:max-w-full"
+            className="break-all select-none md:select-text [&_a]:break-all [&_img]:h-auto [&_img]:max-w-full"
           />
         ) : (
           <Text
@@ -99,7 +99,7 @@ export const PostBody = ({
             as="p"
             typography="body-16-regular"
             textColor="gray-800"
-            className="break-all whitespace-pre-wrap"
+            className="break-all whitespace-pre-wrap select-none md:select-text"
             style={collapseStyles}
           >
             {linkifiedContent}

--- a/apps/web/src/entities/post/ui/PostBody.tsx
+++ b/apps/web/src/entities/post/ui/PostBody.tsx
@@ -91,7 +91,7 @@ export const PostBody = ({
             dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
             suppressHydrationWarning
             style={collapseStyles}
-            className="break-all select-none md:select-text [&_a]:break-all [&_img]:h-auto [&_img]:max-w-full"
+            className="break-all [&_a]:break-all [&_img]:h-auto [&_img]:max-w-full"
           />
         ) : (
           <Text
@@ -99,7 +99,7 @@ export const PostBody = ({
             as="p"
             typography="body-16-regular"
             textColor="gray-800"
-            className="break-all whitespace-pre-wrap select-none md:select-text"
+            className="break-all whitespace-pre-wrap"
             style={collapseStyles}
           >
             {linkifiedContent}


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #295


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 모바일 환경에서 게시글 본문 텍스트 선택을 비활성화하여 Android 컨텍스트 메뉴 노출 이슈를 방지합니다.


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- 게시글 본문 HTML/일반 텍스트 렌더링 영역에 `select-none md:select-text` 클래스를 적용했습니다.
- 모바일 뷰포트에서는 텍스트 선택을 막고, `md` 이상 화면에서는 기존처럼 텍스트 선택이 가능하도록 유지했습니다.
- 게시글 내 자동 링크 텍스트 색상을 명시적으로 파란색으로 조정했습니다.


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- 모바일 환경에서 게시글 본문 롱프레스/드래그 선택이 차단되는지 확인해주세요.
- Android 앱에서 텍스트 선택 컨텍스트 메뉴로 인한 흰색 박스가 더 이상 노출되지 않는지 확인해주세요.
- 데스크톱 또는 `md` 이상 화면에서 기존 텍스트 선택 동작이 유지되는지 확인해주세요.


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.

- `pnpm --filter @causw/web lint` 통과
- 기존 lint warning 5건 확인: 이번 변경 파일과 무관한 React Hook Form watch/exhaustive-deps 경고입니다.


## 📎 Additional Notes
- Android 앱 내 컨텍스트 메뉴 흰색 박스 노출 이슈 대응을 위한 임시방편입니다.