### PR TITLE
[FEAT/#301] 크롤링된 게시물의 링크 css 수정

### DIFF
--- a/apps/web/src/entities/post/ui/PostBody.tsx
+++ b/apps/web/src/entities/post/ui/PostBody.tsx
@@ -91,7 +91,7 @@ export const PostBody = ({
             dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
             suppressHydrationWarning
             style={collapseStyles}
-            className="break-all [&_a]:break-all [&_img]:h-auto [&_img]:max-w-full"
+            className="break-all [&_a]:break-all [&_a]:text-blue-600 [&_a]:underline [&_img]:h-auto [&_img]:max-w-full"
           />
         ) : (
           <Text


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #301


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 크롤링된 게시글의 링크 텍스트 색상을 일반 게시글 링크 스타일과 동일하게 수정했습니다.


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- `feat: 크롤링 게시글 링크 텍스트 색상 수정`
- HTML 본문 내부 `<a>` 태그에 `text-blue-600` 색상과 underline 스타일을 적용했습니다.
- 크롤링된 게시글 링크가 본문 기본 회색 텍스트와 구분되도록 조정했습니다.


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- 크롤링된 HTML 게시글 링크의 색상 및 밑줄 표시가 의도대로 노출되는지 확인해주세요.
- 일반 텍스트 게시글의 링크 스타일과 시각적으로 일관적인지 확인해주세요.


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.

- `pnpm --filter @causw/web lint` 통과
- 기존 warning 5건 확인: auth/image 관련 warning이며 이번 변경 파일과 무관합니다.


## 📎 Additional Notes
- 시니어 프론트 관점에서 변경 범위를 리뷰했고, PR 생성을 막을 만한 큰 문제는 발견하지 못했습니다.