### PR TITLE
fix: 찜하기 삭제에 따른 dto 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ next-env.d.ts
 
 # mcp
 mcp.json
+
+.claude

--- a/apps/web/src/entities/post/model/types/dto/getPostDto.ts
+++ b/apps/web/src/entities/post/model/types/dto/getPostDto.ts
@@ -10,13 +10,11 @@ export interface GetPostResponseDto {
   fileUrlList: string[];
   numComment: number;
   numLike: number;
-  numFavorite: number;
   voteId?: string;
   isAnonymous: boolean;
   isCrawled: boolean;
   isOwner: boolean;
   isPostLike: boolean;
-  isPostFavorite: boolean;
   updatable: boolean;
   deletable: boolean;
   isOfficial: boolean;

--- a/apps/web/src/entities/post/model/types/dto/postResponseDto.ts
+++ b/apps/web/src/entities/post/model/types/dto/postResponseDto.ts
@@ -7,4 +7,5 @@ export type PostResponseDto = Omit<
   postId: string;
   postImageUrls: string[];
   writerNickname: string;
+  isPostFavorite: boolean;
 };


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #306


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- 찜하기 기능 삭제에 따라 게시글 응답 DTO를 변경된 백엔드 스펙에 맞게 수정


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- `GetPostResponseDto`에서 더 이상 내려오지 않는 `numFavorite`, `isPostFavorite` 필드 제거
- `PostResponseDto`에 `isPostFavorite` 필드 추가


## 🎯 Key points to review

- 제거/추가된 필드를 참조하던 다른 코드가 없는지 확인


## 🧪 Test & Verification
- [ ] Storybook UI 확인: N/A (타입/DTO 변경만 포함)
- [x] 타입 에러 없음 확인


## 📎 Additional Notes
- 개발기간: 2026-06-19 ~ 2026-06-19
